### PR TITLE
Add team settings

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -7,7 +7,6 @@ namespace App\Actions\Fortify;
 use App\Actions\JoinTeam;
 use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
-use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Actions\Fortify;
 
-use App\Actions\JoinTeam;
 use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
 use App\Models\User;
@@ -31,17 +30,6 @@ class CreateNewUser implements CreatesNewUsers
 
         $user->addTeam($user->name . "'s Team");
 
-        $this->acceptPendingInvitation($user);
-
         return $user;
-    }
-
-    private function acceptPendingInvitation(User $user): void
-    {
-        if (! session()->has('team_invitation_id')) {
-            return;
-        }
-
-        JoinTeam::handle($user, session()->pull('team_invitation_id'));
     }
 }

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Fortify;
 
+use App\Actions\JoinTeam;
 use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
@@ -30,6 +32,17 @@ class CreateNewUser implements CreatesNewUsers
 
         $user->addTeam($user->name . "'s Team");
 
+        $this->acceptPendingInvitation($user);
+
         return $user;
+    }
+
+    private function acceptPendingInvitation(User $user): void
+    {
+        if (! session()->has('team_invitation_id')) {
+            return;
+        }
+
+        JoinTeam::handle($user, session()->pull('team_invitation_id'));
     }
 }

--- a/app/Actions/InviteTeamMember.php
+++ b/app/Actions/InviteTeamMember.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Notifications\TeamInvitationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class InviteTeamMember
+{
+    public static function handle(Team $team, string $email): TeamInvitation
+    {
+        $invitation = $team->invitations()->create(['email' => $email]);
+
+        Notification::route('mail', $email)
+            ->notify(new TeamInvitationNotification($invitation));
+
+        return $invitation;
+    }
+}

--- a/app/Actions/JoinTeam.php
+++ b/app/Actions/JoinTeam.php
@@ -17,6 +17,12 @@ class JoinTeam
 
             abort_if($user->email !== $invitation->email, 403, __('This invitation belongs to a different email address.'));
 
+            if ($invitation->team->hasUser($user)) {
+                $invitation->delete();
+
+                return;
+            }
+
             $invitation->team->users()->attach($user);
             $user->switchTeam($invitation->team);
             $invitation->delete();

--- a/app/Actions/JoinTeam.php
+++ b/app/Actions/JoinTeam.php
@@ -17,13 +17,10 @@ class JoinTeam
 
             abort_if($user->email !== $invitation->email, 403, __('This invitation belongs to a different email address.'));
 
-            if ($invitation->team->hasUser($user)) {
-                $invitation->delete();
-
-                return;
+            if (! $invitation->team->hasUser($user)) {
+                $invitation->team->users()->attach($user);
             }
 
-            $invitation->team->users()->attach($user);
             $user->switchTeam($invitation->team);
             $invitation->delete();
         });

--- a/app/Actions/JoinTeam.php
+++ b/app/Actions/JoinTeam.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class JoinTeam
+{
+    public static function handle(User $user, int $invitationId): void
+    {
+        DB::transaction(function () use ($user, $invitationId) {
+            $invitation = TeamInvitation::with('team')->findOrFail($invitationId);
+
+            abort_if($user->email !== $invitation->email, 403, __('This invitation belongs to a different email address.'));
+
+            $invitation->team->users()->attach($user);
+            $user->switchTeam($invitation->team);
+            $invitation->delete();
+        });
+    }
+}

--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -39,11 +39,6 @@ trait HasTeams
         return $this->ownsTeam($team) || $this->teams->contains($team);
     }
 
-    public function isCurrentTeam(Team $team): bool
-    {
-        return $this->current_team_id === $team->id;
-    }
-
     public function addTeam(string $name): Team
     {
         $team = $this->ownedTeams()->create([

--- a/app/Concerns/PasswordValidationRules.php
+++ b/app/Concerns/PasswordValidationRules.php
@@ -4,26 +4,18 @@ declare(strict_types=1);
 
 namespace App\Concerns;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 
 trait PasswordValidationRules
 {
-    /**
-     * Get the validation rules used to validate passwords.
-     *
-     * @return array<int, Rule|array<mixed>|string>
-     */
+    /** @return array<int, Rule|array<mixed>|string> */
     protected function passwordRules(): array
     {
         return ['required', 'string', Password::default(), 'confirmed'];
     }
 
-    /**
-     * Get the validation rules used to validate the current password.
-     *
-     * @return array<int, Rule|array<mixed>|string>
-     */
+    /** @return array<int, Rule|array<mixed>|string> */
     protected function currentPasswordRules(): array
     {
         return ['required', 'string', 'current_password'];

--- a/app/Concerns/ProfileValidationRules.php
+++ b/app/Concerns/ProfileValidationRules.php
@@ -9,11 +9,7 @@ use Illuminate\Validation\Rule;
 
 trait ProfileValidationRules
 {
-    /**
-     * Get the validation rules used to validate user profiles.
-     *
-     * @return array<string, array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>>
-     */
+    /** @return array<string, array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>> */
     protected function profileRules(?int $userId = null): array
     {
         return [
@@ -22,21 +18,13 @@ trait ProfileValidationRules
         ];
     }
 
-    /**
-     * Get the validation rules used to validate user names.
-     *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>
-     */
+    /** @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string> */
     protected function nameRules(): array
     {
         return ['required', 'string', 'max:255'];
     }
 
-    /**
-     * Get the validation rules used to validate user emails.
-     *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>
-     */
+    /** @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string> */
     protected function emailRules(?int $userId = null): array
     {
         return [

--- a/app/Concerns/ProfileValidationRules.php
+++ b/app/Concerns/ProfileValidationRules.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Concerns;
 
+use App\Models\TeamInvitation;
 use App\Models\User;
+use Closure;
 use Illuminate\Validation\Rule;
 
 trait ProfileValidationRules
@@ -35,6 +37,15 @@ trait ProfileValidationRules
             $userId === null
                 ? Rule::unique(User::class)
                 : Rule::unique(User::class)->ignore($userId),
+            function (string $attribute, mixed $value, Closure $fail) {
+                if (session()->has('team_invitation_id')) {
+                    $invitation = TeamInvitation::find(session()->get('team_invitation_id'));
+
+                    if ($invitation->email !== $value) {
+                        $fail("The {$attribute} must match the {$attribute} on the invitation.");
+                    }
+                }
+            },
         ];
     }
 }

--- a/app/Concerns/ProfileValidationRules.php
+++ b/app/Concerns/ProfileValidationRules.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Concerns;
 
-use App\Models\TeamInvitation;
 use App\Models\User;
-use Closure;
+use App\Rules\InvitationEmailMatch;
 use Illuminate\Validation\Rule;
 
 trait ProfileValidationRules
@@ -37,15 +36,7 @@ trait ProfileValidationRules
             $userId === null
                 ? Rule::unique(User::class)
                 : Rule::unique(User::class)->ignore($userId),
-            function (string $attribute, mixed $value, Closure $fail) {
-                if (session()->has('team_invitation_id')) {
-                    $invitation = TeamInvitation::find(session()->get('team_invitation_id'));
-
-                    if ($invitation->email !== $value) {
-                        $fail("The {$attribute} must match the {$attribute} on the invitation.");
-                    }
-                }
-            },
+            new InvitationEmailMatch,
         ];
     }
 }

--- a/app/Http/Controllers/AcceptTeamInvitation.php
+++ b/app/Http/Controllers/AcceptTeamInvitation.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Actions\JoinTeam;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AcceptTeamInvitation extends Controller
+{
+    public function __invoke(TeamInvitation $invitation): RedirectResponse
+    {
+        if (Auth::check()) {
+            JoinTeam::handle(Auth::user(), $invitation->id);
+
+            return to_route('dashboard');
+        }
+
+        session(['team_invitation_id' => $invitation->id]);
+
+        $existingUser = User::query()->where('email', $invitation->email)->exists();
+
+        return to_route($existingUser ? 'login' : 'register');
+    }
+}

--- a/app/Http/Controllers/AcceptTeamInvitation.php
+++ b/app/Http/Controllers/AcceptTeamInvitation.php
@@ -8,7 +8,6 @@ use App\Actions\JoinTeam;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class AcceptTeamInvitation extends Controller

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Rules\InvitationEmailMatch;
+use Laravel\Fortify\Fortify;
+use Laravel\Fortify\Http\Requests\LoginRequest as FortifyLoginRequest;
+
+class LoginRequest extends FortifyLoginRequest
+{
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            Fortify::username() => ['required', 'string', new InvitationEmailMatch],
+            'password' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Listeners/AcceptPendingInvitation.php
+++ b/app/Listeners/AcceptPendingInvitation.php
@@ -6,6 +6,7 @@ namespace App\Listeners;
 
 use App\Actions\JoinTeam;
 use Illuminate\Auth\Events\Login;
+use Throwable;
 
 class AcceptPendingInvitation
 {
@@ -15,6 +16,11 @@ class AcceptPendingInvitation
             return;
         }
 
-        JoinTeam::handle($event->user, session()->pull('team_invitation_id'));
+        try {
+            JoinTeam::handle($event->user, session()->pull('team_invitation_id'));
+        } catch (Throwable) {
+            // Invitation may have been deleted or belong to a different email.
+            // Fail silently so the login is not interrupted.
+        }
     }
 }

--- a/app/Listeners/AcceptPendingInvitation.php
+++ b/app/Listeners/AcceptPendingInvitation.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Actions\JoinTeam;
+use Illuminate\Auth\Events\Login;
+
+class AcceptPendingInvitation
+{
+    public function handle(Login $event): void
+    {
+        if (! session()->has('team_invitation_id')) {
+            return;
+        }
+
+        JoinTeam::handle($event->user, session()->pull('team_invitation_id'));
+    }
+}

--- a/app/Notifications/TeamInvitationNotification.php
+++ b/app/Notifications/TeamInvitationNotification.php
@@ -26,7 +26,7 @@ class TeamInvitationNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         $teamName = $this->invitation->team->name;
-        $acceptUrl = URL::signedRoute('team-invitation.accept', $this->invitation);
+        $acceptUrl = URL::signedRoute('invitation.accept', $this->invitation);
 
         return (new MailMessage)
             ->subject(__("You've been invited to join :team", ['team' => $teamName]))

--- a/app/Notifications/TeamInvitationNotification.php
+++ b/app/Notifications/TeamInvitationNotification.php
@@ -26,12 +26,14 @@ class TeamInvitationNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         $teamName = $this->invitation->team->name;
-        $acceptUrl = URL::signedRoute('invitation.accept', $this->invitation);
+        $expiresAt = now()->addDays(7);
+        $acceptUrl = URL::temporarySignedRoute('invitation.accept', $expiresAt, $this->invitation);
 
         return (new MailMessage)
             ->subject(__("You've been invited to join :team", ['team' => $teamName]))
             ->line(__("You've been invited to join the :team team.", ['team' => $teamName]))
             ->action(__('Accept Invitation'), $acceptUrl)
+            ->line(__('This invitation will expire on :date.', ['date' => $expiresAt->toDayDateTimeString()]))
             ->line(__('If you did not expect to receive this invitation, you may discard this email.'));
     }
 }

--- a/app/Notifications/TeamInvitationNotification.php
+++ b/app/Notifications/TeamInvitationNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\TeamInvitation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\URL;
+
+class TeamInvitationNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public TeamInvitation $invitation) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $teamName = $this->invitation->team->name;
+        $acceptUrl = URL::signedRoute('team-invitation.accept', $this->invitation);
+
+        return (new MailMessage)
+            ->subject(__("You've been invited to join :team", ['team' => $teamName]))
+            ->line(__("You've been invited to join the :team team.", ['team' => $teamName]))
+            ->action(__('Accept Invitation'), $acceptUrl)
+            ->line(__('If you did not expect to receive this invitation, you may discard this email.'));
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -6,18 +6,20 @@ namespace App\Providers;
 
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
+use App\Http\Requests\LoginRequest;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Fortify;
+use Laravel\Fortify\Http\Requests\LoginRequest as FortifyLoginRequest;
 
 class FortifyServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        //
+        $this->app->bind(FortifyLoginRequest::class, LoginRequest::class);
     }
 
     public function boot(): void

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -15,17 +15,11 @@ use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
     public function register(): void
     {
         //
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
         $this->configureActions();
@@ -33,18 +27,12 @@ class FortifyServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
     }
 
-    /**
-     * Configure Fortify actions.
-     */
     private function configureActions(): void
     {
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
         Fortify::createUsersUsing(CreateNewUser::class);
     }
 
-    /**
-     * Configure Fortify views.
-     */
     private function configureViews(): void
     {
         Fortify::loginView(fn () => view('pages::auth.login'));
@@ -56,9 +44,6 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::requestPasswordResetLinkView(fn () => view('pages::auth.forgot-password'));
     }
 
-    /**
-     * Configure rate limiting.
-     */
     private function configureRateLimiting(): void
     {
         RateLimiter::for('two-factor', function (Request $request) {

--- a/app/Rules/InvitationEmailMatch.php
+++ b/app/Rules/InvitationEmailMatch.php
@@ -22,7 +22,13 @@ class InvitationEmailMatch implements ValidationRule
 
         $invitation = TeamInvitation::find(session()->get('team_invitation_id'));
 
-        if ($invitation && $invitation->email !== $value) {
+        if (! $invitation) {
+            session()->forget('team_invitation_id');
+
+            return;
+        }
+
+        if ($invitation->email !== $value) {
             $fail("The {$attribute} must match the {$attribute} on the invitation.");
         }
     }

--- a/app/Rules/InvitationEmailMatch.php
+++ b/app/Rules/InvitationEmailMatch.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Models\TeamInvitation;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class InvitationEmailMatch implements ValidationRule
+{
+    /**
+     * @param  Closure(string, ?string=):PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! session()->has('team_invitation_id')) {
+            return;
+        }
+
+        $invitation = TeamInvitation::find(session()->get('team_invitation_id'));
+
+        if ($invitation && $invitation->email !== $value) {
+            $fail("The {$attribute} must match the {$attribute} on the invitation.");
+        }
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,6 +12,11 @@
                     <flux:sidebar.item icon="home" :href="route('dashboard')" :current="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </flux:sidebar.item>
+                    @if (auth()->user()->ownsTeam(auth()->user()->currentTeam))
+                        <flux:sidebar.item icon="user-group" :href="route('team.edit')" :current="request()->routeIs('team.edit')" wire:navigate>
+                            {{ __('Team Settings') }}
+                        </flux:sidebar.item>
+                    @endif
                 </flux:sidebar.group>
             </flux:sidebar.nav>
 

--- a/resources/views/pages/settings/layout.blade.php
+++ b/resources/views/pages/settings/layout.blade.php
@@ -2,6 +2,9 @@
     <div class="me-10 w-full pb-4 md:w-[220px]">
         <flux:navlist aria-label="{{ __('Settings') }}">
             <flux:navlist.item :href="route('profile.edit')" wire:navigate>{{ __('Profile') }}</flux:navlist.item>
+            @if (auth()->user()->ownsTeam(auth()->user()->currentTeam))
+                <flux:navlist.item :href="route('team.edit')" wire:navigate>{{ __('Team') }}</flux:navlist.item>
+            @endif
             <flux:navlist.item :href="route('user-password.edit')" wire:navigate>{{ __('Password') }}</flux:navlist.item>
             @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
                 <flux:navlist.item :href="route('two-factor.show')" wire:navigate>{{ __('Two-Factor Auth') }}</flux:navlist.item>

--- a/resources/views/pages/settings/⚡team.blade.php
+++ b/resources/views/pages/settings/⚡team.blade.php
@@ -1,33 +1,81 @@
 <?php
 
+use App\Models\Team;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Illuminate\Support\Collection;
 
 new class extends Component {
     public string $name = '';
 
+    public string $email = '';
+
     public function mount(): void
     {
-        $user = Auth::user();
+        abort_unless(Auth::user()->ownsTeam($this->team), 403);
 
-        if (! $user->ownsTeam($user->currentTeam)) {
-            abort(403);
-        }
+        $this->name = $this->team->name;
+    }
 
-        $this->name = $user->currentTeam->name;
+    #[Computed]
+    public function invitations(): Collection
+    {
+        return $this->team->invitations;
+    }
+
+    #[Computed]
+    public function members(): Collection
+    {
+        return $this->team->users;
+    }
+
+    #[Computed]
+    public function team(): Team
+    {
+        return Auth::user()->currentTeam;
+    }
+
+    public function inviteMember(): void
+    {
+        $this->validate([
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                function (string $attribute, mixed $value, $fail): void {
+                    $existingUser = User::query()->where('email', $value)->first();
+
+                    if ($existingUser && $this->team->hasUser($existingUser)) {
+                        $fail(__('This user is already a team member.'));
+                    }
+                },
+                Rule::unique('team_invitations', 'email')
+                    ->where(fn ($query) => $query->where('team_id', $this->team->id)),
+            ],
+        ], [
+            'email.unique' => __('This email has already been invited.'),
+        ]);
+
+
+        $this->team->invitations()->create(['email' => $this->email]);
+
+        $this->modal('invite-member')->close();
+        $this->reset('email');
+
+        unset($this->members);
+        unset($this->invitations);
     }
 
     public function updateTeamName(): void
     {
-        $user = Auth::user();
-
-        if (! $user->ownsTeam($user->currentTeam)) {
-            abort(403);
-        }
+        abort_unless(Auth::user()->ownsTeam($this->team), 403);
 
         $this->validate(['name' => ['required', 'string', 'max:255']]);
 
-        $user->currentTeam->update(['name' => $this->name]);
+        $this->team->update(['name' => $this->name]);
 
         $this->dispatch('team-updated');
     }
@@ -38,9 +86,9 @@ new class extends Component {
 
     <flux:heading class="sr-only">{{ __('Team Settings') }}</flux:heading>
 
-    <x-pages::settings.layout :heading="__('Team')" :subheading="__('Update your team\'s name')">
+    <x-pages::settings.layout :heading="__('Team')" :subheading="__('Update your team\'s information')">
         <form wire:submit="updateTeamName" class="my-6 w-full space-y-6">
-            <flux:input wire:model="name" :label="__('Name')" type="text" required autofocus autocomplete="off" />
+            <flux:input wire:model="name" :label="__('Team Name')" type="text" required autofocus autocomplete="off" />
 
             <div class="flex items-center gap-4">
                 <div class="flex items-center justify-end">
@@ -54,5 +102,71 @@ new class extends Component {
                 </x-action-message>
             </div>
         </form>
+
+        <flux:separator class="my-10" />
+
+        <div class="flex items-center justify-between gap-4 mb-4">
+            <div>
+                <flux:heading size="lg">{{ __('Team Members') }}</flux:heading>
+                <flux:subheading>{{ __('Manage your team\'s members and invitations') }}</flux:subheading>
+            </div>
+            <div>
+                <flux:modal.trigger name="invite-member">
+                    <flux:button variant="primary" size="sm">{{ __('Invite') }}</flux:button>
+                </flux:modal.trigger>
+            </div>
+        </div>
+
+        <flux:table>
+            <flux:table.columns>
+                <flux:table.column>{{ __('Name') }}</flux:table.column>
+                <flux:table.column>{{ __('Email') }}</flux:table.column>
+                <flux:table.column>{{ __('Status') }}</flux:table.column>
+            </flux:table.columns>
+
+            <flux:table.rows>
+                @foreach ($this->members as $member)
+                    <flux:table.row :wire:key="'member-'.$member->id">
+                        <flux:table.cell>{{ $member->name }}</flux:table.cell>
+                        <flux:table.cell>{{ $member->email }}</flux:table.cell>
+                        <flux:table.cell>
+                            @if ($this->team->user_id === $member->id)
+                                <flux:badge size="sm" color="blue">{{ __('Owner') }}</flux:badge>
+                            @else
+                                <flux:badge size="sm" color="green">{{ __('Member') }}</flux:badge>
+                            @endif
+                        </flux:table.cell>
+                    </flux:table.row>
+                @endforeach
+
+                @foreach ($this->invitations as $invitation)
+                    <flux:table.row :wire:key="'invitation-'.$invitation->id">
+                        <flux:table.cell>&mdash;</flux:table.cell>
+                        <flux:table.cell>{{ $invitation->email }}</flux:table.cell>
+                        <flux:table.cell>
+                            <flux:badge size="sm" color="yellow">{{ __('Invited') }}</flux:badge>
+                        </flux:table.cell>
+                    </flux:table.row>
+                @endforeach
+            </flux:table.rows>
+        </flux:table>
     </x-pages::settings.layout>
+
+    @teleport('body')
+    <flux:modal name="invite-member" class="md:w-96">
+        <form wire:submit="inviteMember" class="space-y-6">
+            <flux:heading size="lg">{{ __('Invite member') }}</flux:heading>
+
+            <flux:input wire:model="email" :label="__('Email')" type="email" />
+
+            <div class="flex">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button variant="ghost" class="mr-2">{{ __('Cancel') }}</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="primary">{{ __('Send invite') }}</flux:button>
+            </div>
+        </form>
+    </flux:modal>
+    @endteleport
 </section>

--- a/resources/views/pages/settings/⚡team.blade.php
+++ b/resources/views/pages/settings/⚡team.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\InviteTeamMember;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
@@ -59,13 +60,11 @@ new class extends Component {
             'email.unique' => __('This email has already been invited.'),
         ]);
 
-
-        $this->team->invitations()->create(['email' => $this->email]);
+        InviteTeamMember::handle($this->team, $this->email);
 
         $this->modal('invite-member')->close();
         $this->reset('email');
 
-        unset($this->members);
         unset($this->invitations);
     }
 

--- a/resources/views/pages/settings/⚡team.blade.php
+++ b/resources/views/pages/settings/⚡team.blade.php
@@ -2,6 +2,7 @@
 
 use App\Actions\InviteTeamMember;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -41,6 +42,8 @@ new class extends Component {
 
     public function inviteMember(): void
     {
+        abort_unless(Auth::user()->ownsTeam($this->team), 403);
+
         $this->validate([
             'email' => [
                 'required',
@@ -64,6 +67,20 @@ new class extends Component {
 
         $this->modal('invite-member')->close();
         $this->reset('email');
+
+        unset($this->invitations);
+    }
+
+    public function cancelInvitation(int $invitationId): void
+    {
+        abort_unless(Auth::user()->ownsTeam($this->team), 403);
+
+        $invitation = TeamInvitation::query()
+            ->where('id', $invitationId)
+            ->where('team_id', $this->team->id)
+            ->firstOrFail();
+
+        $invitation->delete();
 
         unset($this->invitations);
     }
@@ -121,6 +138,7 @@ new class extends Component {
                 <flux:table.column>{{ __('Name') }}</flux:table.column>
                 <flux:table.column>{{ __('Email') }}</flux:table.column>
                 <flux:table.column>{{ __('Status') }}</flux:table.column>
+                <flux:table.column></flux:table.column>
             </flux:table.columns>
 
             <flux:table.rows>
@@ -135,6 +153,7 @@ new class extends Component {
                                 <flux:badge size="sm" color="green">{{ __('Member') }}</flux:badge>
                             @endif
                         </flux:table.cell>
+                        <flux:table.cell></flux:table.cell>
                     </flux:table.row>
                 @endforeach
 
@@ -144,6 +163,11 @@ new class extends Component {
                         <flux:table.cell>{{ $invitation->email }}</flux:table.cell>
                         <flux:table.cell>
                             <flux:badge size="sm" color="yellow">{{ __('Invited') }}</flux:badge>
+                        </flux:table.cell>
+                        <flux:table.cell>
+                            <flux:button variant="ghost" size="sm" wire:click="cancelInvitation({{ $invitation->id }})" wire:confirm="{{ __('Are you sure you want to cancel this invitation?') }}">
+                                {{ __('Cancel') }}
+                            </flux:button>
                         </flux:table.cell>
                     </flux:table.row>
                 @endforeach

--- a/resources/views/pages/settings/⚡team.blade.php
+++ b/resources/views/pages/settings/⚡team.blade.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+new class extends Component {
+    public string $name = '';
+
+    public function mount(): void
+    {
+        $user = Auth::user();
+
+        if (! $user->ownsTeam($user->currentTeam)) {
+            abort(403);
+        }
+
+        $this->name = $user->currentTeam->name;
+    }
+
+    public function updateTeamName(): void
+    {
+        $user = Auth::user();
+
+        if (! $user->ownsTeam($user->currentTeam)) {
+            abort(403);
+        }
+
+        $this->validate(['name' => ['required', 'string', 'max:255']]);
+
+        $user->currentTeam->update(['name' => $this->name]);
+
+        $this->dispatch('team-updated');
+    }
+}; ?>
+
+<section class="w-full">
+    @include('pages.settings.heading')
+
+    <flux:heading class="sr-only">{{ __('Team Settings') }}</flux:heading>
+
+    <x-pages::settings.layout :heading="__('Team')" :subheading="__('Update your team\'s name')">
+        <form wire:submit="updateTeamName" class="my-6 w-full space-y-6">
+            <flux:input wire:model="name" :label="__('Name')" type="text" required autofocus autocomplete="off" />
+
+            <div class="flex items-center gap-4">
+                <div class="flex items-center justify-end">
+                    <flux:button variant="primary" type="submit" class="w-full">
+                        {{ __('Save') }}
+                    </flux:button>
+                </div>
+
+                <x-action-message class="me-3" on="team-updated">
+                    {{ __('Saved.') }}
+                </x-action-message>
+            </div>
+        </form>
+    </x-pages::settings.layout>
+</section>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -7,6 +7,7 @@ Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');
 
     Route::livewire('settings/profile', 'pages::settings.profile')->name('profile.edit');
+    Route::livewire('settings/team', 'pages::settings.team')->name('team.edit');
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AcceptTeamInvitation;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -9,5 +10,9 @@ Route::get('/', function () {
 Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
+
+Route::get('invitations/{invitation}/accept', AcceptTeamInvitation::class)
+    ->name('invitation.accept')
+    ->middleware('signed');
 
 require __DIR__ . '/settings.php';

--- a/tests/Feature/Http/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Http/AcceptTeamInvitationTest.php
@@ -125,6 +125,18 @@ test('cannot login with different email than invitation', function () {
         ->assertInvalid(['email' => 'must match']);
 });
 
+test('expired signed url returns 403', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->create(['name' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
+
+    $acceptUrl = URL::temporarySignedRoute('invitation.accept', now()->subDay(), $invitation);
+
+    $this->actingAs($zoro)
+        ->get($acceptUrl)
+        ->assertForbidden();
+});
+
 test('tampered signed url returns 403', function () {
     $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
     $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);

--- a/tests/Feature/Http/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Http/AcceptTeamInvitationTest.php
@@ -139,7 +139,7 @@ test('expired signed url returns 403', function () {
 
 test('already a member gracefully handles duplicate join', function () {
     $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
-    $zoro = User::factory()->create(['name' => 'zoro@strawhat.pirates']);
+    $zoro = User::factory()->withTeam()->create(['name' => 'zoro@strawhat.pirates']);
     $luffy->currentTeam->users()->attach($zoro);
     $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
 
@@ -149,7 +149,8 @@ test('already a member gracefully handles duplicate join', function () {
         ->get($acceptUrl)
         ->assertRedirect(route('dashboard'));
 
-    expect(TeamInvitation::find($invitation->id))->toBeNull();
+    expect($zoro->fresh()->current_team_id)->toBe($luffy->currentTeam->id)
+        ->and(TeamInvitation::find($invitation->id))->toBeNull();
 });
 
 test('tampered signed url returns 403', function () {

--- a/tests/Feature/Http/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Http/AcceptTeamInvitationTest.php
@@ -137,6 +137,21 @@ test('expired signed url returns 403', function () {
         ->assertForbidden();
 });
 
+test('already a member gracefully handles duplicate join', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->create(['name' => 'zoro@strawhat.pirates']);
+    $luffy->currentTeam->users()->attach($zoro);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
+
+    $acceptUrl = URL::signedRoute('invitation.accept', $invitation);
+
+    $this->actingAs($zoro)
+        ->get($acceptUrl)
+        ->assertRedirect(route('dashboard'));
+
+    expect(TeamInvitation::find($invitation->id))->toBeNull();
+});
+
 test('tampered signed url returns 403', function () {
     $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
     $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);

--- a/tests/Feature/Http/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Http/AcceptTeamInvitationTest.php
@@ -123,7 +123,7 @@ test('cannot login with different email than invitation', function () {
             'password' => 'password',
         ])
         ->assertInvalid(['email' => 'must match']);
-})->todo();
+});
 
 test('tampered signed url returns 403', function () {
     $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);

--- a/tests/Feature/Http/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Http/AcceptTeamInvitationTest.php
@@ -76,6 +76,32 @@ test('pending invitation is auto-accepted after registration', function () {
         ->and(TeamInvitation::find($invitation->id))->toBeNull();
 });
 
+test('deleted invitation clears session and allows registration', function () {
+    $this->withSession(['team_invitation_id' => 999])
+        ->post(route('register'), [
+            'name' => 'Roronoa Zoro',
+            'email' => 'zoro@strawhat.pirates',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ])
+        ->assertValid('email');
+
+    expect(session()->has('team_invitation_id'))->toBeFalse();
+});
+
+test('deleted invitation clears session and allows login', function () {
+    User::factory()->withTeam()->create(['email' => 'zoro@strawhat.pirates']);
+
+    $this->withSession(['team_invitation_id' => 999])
+        ->post(route('login'), [
+            'email' => 'zoro@strawhat.pirates',
+            'password' => 'password',
+        ])
+        ->assertValid('email');
+
+    expect(session()->has('team_invitation_id'))->toBeFalse();
+});
+
 test('cannot register with different email', function () {
     $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
     $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);

--- a/tests/Feature/Http/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Http/AcceptTeamInvitationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\URL;
+
+test('existing user can accept invitation', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->create(['name' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
+
+    $acceptUrl = URL::signedRoute('invitation.accept', $invitation);
+
+    $this->actingAs($zoro)
+        ->get($acceptUrl)
+        ->assertRedirect(route('dashboard'));
+
+    expect($luffy->currentTeam->fresh()->users->pluck('id'))->toContain($zoro->id)
+        ->and($zoro->fresh()->current_team_id)->toBe($luffy->currentTeam->id)
+        ->and(TeamInvitation::find($invitation->id))->toBeNull();
+});
+
+test('cannot accept invitation for wrong email', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->create(['name' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'nami@strawhat.pirates']);
+
+    $acceptUrl = URL::signedRoute('invitation.accept', $invitation);
+
+    $this->actingAs($zoro)
+        ->get($acceptUrl)
+        ->assertForbidden();
+});
+
+test('unauthenticated user with existing account is redirected to login', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->create(['name' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
+
+    $acceptUrl = URL::signedRoute('invitation.accept', $invitation);
+
+    $this->get($acceptUrl)
+        ->assertRedirect(route('login'));
+
+    expect(session('team_invitation_id'))->toBe($invitation->id);
+});
+
+test('unauthenticated user without account is redirected to register', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);
+
+    $acceptUrl = URL::signedRoute('invitation.accept', $invitation);
+
+    $this->get($acceptUrl)
+        ->assertRedirect(route('register'));
+
+    expect(session('team_invitation_id'))->toBe($invitation->id);
+});
+
+test('pending invitation is auto-accepted after registration', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);
+
+    $this->withSession(['team_invitation_id' => $invitation->id])
+        ->post(route('register'), [
+            'name' => 'Roronoa Zoro',
+            'email' => 'zoro@strawhat.pirates',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+    $zoro = User::where('email', 'zoro@strawhat.pirates')->first();
+
+    expect($luffy->currentTeam->fresh()->users->pluck('id'))->toContain($zoro->id)
+        ->and($zoro->current_team_id)->toBe($luffy->currentTeam->id)
+        ->and(TeamInvitation::find($invitation->id))->toBeNull();
+});
+
+test('cannot register with different email', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);
+
+    $this->withSession(['team_invitation_id' => $invitation->id])
+        ->post(route('register'), [
+            'name' => 'Roronoa Zoro',
+            'email' => 'zoro@baroqueworks.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ])
+        ->assertInvalid(['email' => 'must match']);
+});
+
+test('pending invitation is auto-accepted after login', function () {
+    $luffy = User::factory()->withTeam()->create(['email' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->withTeam()->create(['email' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
+
+    $this->withSession(['team_invitation_id' => $invitation->id])
+        ->post(route('login'), [
+            'email' => $zoro->email,
+            'password' => 'password',
+        ]);
+
+    expect($luffy->currentTeam->fresh()->users->pluck('id'))->toContain($zoro->id)
+        ->and($zoro->fresh()->current_team_id)->toBe($luffy->currentTeam->id)
+        ->and(TeamInvitation::find($invitation->id))->toBeNull();
+});
+
+test('cannot login with different email than invitation', function () {
+    $luffy = User::factory()->withTeam()->create(['email' => 'luffy@strawhat.pirates']);
+    [$sanjiOld, $sanjiNew] = User::factory()
+        ->count(2)
+        ->sequence(
+            ['email' => 'sanji@baratie.restaurant'],
+            ['email' => 'sanji@strawhat.pirates'],
+        )
+        ->create();
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $sanjiNew->email]);
+
+    $this->withSession(['team_invitation_id' => $invitation->id])
+        ->post(route('login'), [
+            'email' => $sanjiOld->email,
+            'password' => 'password',
+        ])
+        ->assertInvalid(['email' => 'must match']);
+})->todo();
+
+test('tampered signed url returns 403', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'zoro@strawhat.pirates']);
+
+    $acceptUrl = URL::signedRoute('invitation.accept', $invitation);
+
+    $this->get($acceptUrl . '&tampered=true')
+        ->assertForbidden();
+});

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -5,35 +5,31 @@ use Illuminate\Support\Facades\Hash;
 use Livewire\Livewire;
 
 test('password can be updated', function () {
-    $user = User::factory()->create([
+    $user = User::factory()->withTeam()->create([
         'password' => Hash::make('password'),
     ]);
 
-    $this->actingAs($user);
-
-    $response = Livewire::test('pages::settings.password')
+    Livewire::actingAs($user)
+        ->test('pages::settings.password')
         ->set('current_password', 'password')
         ->set('password', 'new-password')
         ->set('password_confirmation', 'new-password')
-        ->call('updatePassword');
-
-    $response->assertHasNoErrors();
+        ->call('updatePassword')
+        ->assertHasNoErrors();
 
     expect(Hash::check('new-password', $user->refresh()->password))->toBeTrue();
 });
 
 test('correct password must be provided to update password', function () {
-    $user = User::factory()->create([
+    $user = User::factory()->withTeam()->create([
         'password' => Hash::make('password'),
     ]);
 
-    $this->actingAs($user);
-
-    $response = Livewire::test('pages::settings.password')
+    Livewire::actingAs($user)
+        ->test('pages::settings.password')
         ->set('current_password', 'wrong-password')
         ->set('password', 'new-password')
         ->set('password_confirmation', 'new-password')
-        ->call('updatePassword');
-
-    $response->assertHasErrors(['current_password']);
+        ->call('updatePassword')
+        ->assertHasErrors(['current_password']);
 });

--- a/tests/Feature/Settings/TeamTest.php
+++ b/tests/Feature/Settings/TeamTest.php
@@ -2,6 +2,8 @@
 
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Notifications\TeamInvitationNotification;
+use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
 test('team settings page is displayed for team owners', function () {
@@ -35,17 +37,24 @@ test('non-owners get a 403 when attempting to render the team settings page', fu
 });
 
 test('owner can invite a member by email', function () {
-    $user = User::factory()->withTeam()->create();
+    Notification::fake();
+
+    $user = User::factory()->withTeam()->create(['name' => 'Monkey D. Luffy']);
 
     Livewire::actingAs($user)
         ->test('pages::settings.team')
-        ->set('email', 'newmember@example.com')
+        ->set('email', 'zoro@strawhat.pirates')
         ->call('inviteMember')
         ->assertHasNoErrors()
         ->assertSet('email', '');
 
-    expect($user->currentTeam->fresh()->invitations)->toHaveCount(1)
-        ->and($user->currentTeam->fresh()->invitations->first()->email)->toEqual('newmember@example.com');
+    $invitations = $user->currentTeam->fresh()->invitations;
+    expect($invitations)->toHaveCount(1)
+        ->and($invitations->first()->email)->toEqual('zoro@strawhat.pirates');
+
+    Notification::assertSentOnDemand(TeamInvitationNotification::class, function ($notification, $channels, $notifiable) {
+        return $notifiable->routes['mail'] === 'zoro@strawhat.pirates';
+    });
 });
 
 test('invite requires a valid email', function () {

--- a/tests/Feature/Settings/TeamTest.php
+++ b/tests/Feature/Settings/TeamTest.php
@@ -3,6 +3,7 @@
 use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Notifications\TeamInvitationNotification;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
@@ -90,6 +91,41 @@ test('cannot invite someone who already has a pending invitation', function () {
         ->call('inviteMember')
         ->assertHasErrors(['email' => 'unique']);
 });
+
+test('owner can cancel a pending invitation', function () {
+    $owner = User::factory()->withTeam()->create();
+    $invitation = TeamInvitation::factory()->for($owner->currentTeam)->create(['email' => 'pending@example.com']);
+
+    Livewire::actingAs($owner)
+        ->test('pages::settings.team')
+        ->call('cancelInvitation', $invitation->id)
+        ->assertHasNoErrors();
+
+    expect(TeamInvitation::find($invitation->id))->toBeNull();
+});
+
+test('non-owner cannot cancel a pending invitation', function () {
+    $owner = User::factory()->withTeam()->create();
+    $member = User::factory()->create();
+    $owner->currentTeam->users()->attach($member);
+    $member->switchTeam($owner->currentTeam);
+
+    $invitation = TeamInvitation::factory()->for($owner->currentTeam)->create(['email' => 'pending@example.com']);
+
+    Livewire::actingAs($member)
+        ->test('pages::settings.team')
+        ->assertStatus(403);
+});
+
+test('cannot cancel invitation belonging to another team', function () {
+    $owner = User::factory()->withTeam()->create();
+    $otherOwner = User::factory()->withTeam()->create();
+    $invitation = TeamInvitation::factory()->for($otherOwner->currentTeam)->create(['email' => 'pending@example.com']);
+
+    Livewire::actingAs($owner)
+        ->test('pages::settings.team')
+        ->call('cancelInvitation', $invitation->id);
+})->throws(ModelNotFoundException::class);
 
 test('members table shows existing members and pending invitations', function () {
     $owner = User::factory()->withTeam()->create();

--- a/tests/Feature/Settings/TeamTest.php
+++ b/tests/Feature/Settings/TeamTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\User;
+use Livewire\Livewire;
+
+test('team settings page is displayed for team owners', function () {
+    $this->actingAs(User::factory()->withTeam()->create())
+        ->get(route('team.edit'))
+        ->assertOk();
+});
+
+test('team name can be updated by team owner', function () {
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.team')
+        ->set('name', 'Updated Team Name')
+        ->call('updateTeamName')
+        ->assertHasNoErrors()
+        ->assertDispatched('team-updated');
+
+    expect($user->currentTeam->fresh()->name)->toEqual('Updated Team Name');
+});
+
+test('non-owners get a 403 when attempting to render the team settings page', function () {
+    $owner = User::factory()->withTeam()->create();
+    $member = User::factory()->create();
+    $owner->currentTeam->users()->attach($member);
+    $member->switchTeam($owner->currentTeam);
+
+    $this->actingAs($member)
+        ->get(route('team.edit'))
+        ->assertForbidden();
+});

--- a/tests/Feature/Settings/TeamTest.php
+++ b/tests/Feature/Settings/TeamTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -31,4 +32,70 @@ test('non-owners get a 403 when attempting to render the team settings page', fu
     $this->actingAs($member)
         ->get(route('team.edit'))
         ->assertForbidden();
+});
+
+test('owner can invite a member by email', function () {
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.team')
+        ->set('email', 'newmember@example.com')
+        ->call('inviteMember')
+        ->assertHasNoErrors()
+        ->assertSet('email', '');
+
+    expect($user->currentTeam->fresh()->invitations)->toHaveCount(1)
+        ->and($user->currentTeam->fresh()->invitations->first()->email)->toEqual('newmember@example.com');
+});
+
+test('invite requires a valid email', function () {
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.team')
+        ->set('email', 'not-an-email')
+        ->call('inviteMember')
+        ->assertHasErrors(['email' => 'email']);
+});
+
+test('cannot invite someone who is already a team member', function () {
+    $owner = User::factory()->withTeam()->create();
+    $member = User::factory()->create();
+    $owner->currentTeam->users()->attach($member);
+
+    Livewire::actingAs($owner)
+        ->test('pages::settings.team')
+        ->set('email', $member->email)
+        ->call('inviteMember')
+        ->assertHasErrors('email');
+});
+
+test('cannot invite someone who already has a pending invitation', function () {
+    $user = User::factory()->withTeam()->create();
+
+    TeamInvitation::factory()->for($user->currentTeam)->create(['email' => 'invited@example.com']);
+
+    Livewire::actingAs($user)
+        ->test('pages::settings.team')
+        ->set('email', 'invited@example.com')
+        ->call('inviteMember')
+        ->assertHasErrors(['email' => 'unique']);
+});
+
+test('members table shows existing members and pending invitations', function () {
+    $owner = User::factory()->withTeam()->create();
+    $member = User::factory()->create();
+    $owner->currentTeam->users()->attach($member);
+
+    TeamInvitation::factory()->for($owner->currentTeam)->create(['email' => 'pending@example.com']);
+
+    Livewire::actingAs($owner)
+        ->test('pages::settings.team')
+        ->assertSee($owner->name)
+        ->assertSee($owner->email)
+        ->assertSee($member->name)
+        ->assertSee($member->email)
+        ->assertSee('pending@example.com')
+        ->assertSee('Member')
+        ->assertSee('Invited');
 });

--- a/tests/Unit/Listeners/AcceptPendingInvitationTest.php
+++ b/tests/Unit/Listeners/AcceptPendingInvitationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Listeners\AcceptPendingInvitation;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Auth\Events\Login;
+
+test('listener accepts pending invitation on login', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->withTeam()->create(['name' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => $zoro->email]);
+
+    session(['team_invitation_id' => $invitation->id]);
+
+    $listener = new AcceptPendingInvitation;
+    $listener->handle(new Login('web', $zoro, false));
+
+    expect($luffy->currentTeam->fresh()->users->pluck('id'))->toContain($zoro->id)
+        ->and(TeamInvitation::find($invitation->id))->toBeNull()
+        ->and(session()->has('team_invitation_id'))->toBeFalse();
+});
+
+test('listener does nothing without session key', function () {
+    $zoro = User::factory()->withTeam()->create(['name' => 'zoro@strawhat.pirates']);
+
+    $listener = new AcceptPendingInvitation;
+    $listener->handle(new Login('web', $zoro, false));
+
+    expect(session()->has('team_invitation_id'))->toBeFalse();
+});
+
+test('listener handles deleted invitation gracefully', function () {
+    $zoro = User::factory()->withTeam()->create(['name' => 'zoro@strawhat.pirates']);
+
+    session(['team_invitation_id' => 999]);
+
+    $listener = new AcceptPendingInvitation;
+    $listener->handle(new Login('web', $zoro, false));
+
+    expect(session()->has('team_invitation_id'))->toBeFalse();
+});
+
+test('listener handles email mismatch gracefully', function () {
+    $luffy = User::factory()->withTeam()->create(['name' => 'luffy@strawhat.pirates']);
+    $zoro = User::factory()->withTeam()->create(['name' => 'zoro@strawhat.pirates']);
+    $invitation = TeamInvitation::factory()->for($luffy->currentTeam)->create(['email' => 'nami@strawhat.pirates']);
+
+    session(['team_invitation_id' => $invitation->id]);
+
+    $listener = new AcceptPendingInvitation;
+    $listener->handle(new Login('web', $zoro, false));
+
+    expect($luffy->currentTeam->fresh()->users->pluck('id'))->not->toContain($zoro->id)
+        ->and(session()->has('team_invitation_id'))->toBeFalse();
+});

--- a/tests/Unit/Notifications/TeamInvitationNotificationTest.php
+++ b/tests/Unit/Notifications/TeamInvitationNotificationTest.php
@@ -13,3 +13,15 @@ test('invitation notification contains accept url', function () {
 
     expect($mail->actionUrl)->toContain('invitations/' . $invitation->id . '/accept');
 });
+
+test('invitation notification contains expiration date', function () {
+    $this->freezeTime();
+
+    $user = User::factory()->withTeam()->create();
+    $invitation = TeamInvitation::factory()->for($user->currentTeam)->create(['email' => 'test@example.com']);
+
+    $mail = new TeamInvitationNotification($invitation)->toMail(new AnonymousNotifiable);
+    $expiresAt = now()->addDays(7)->toDayDateTimeString();
+
+    expect($mail->outroLines)->toContain("This invitation will expire on {$expiresAt}.");
+});

--- a/tests/Unit/Notifications/TeamInvitationNotificationTest.php
+++ b/tests/Unit/Notifications/TeamInvitationNotificationTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Notifications\TeamInvitationNotification;
+use Illuminate\Notifications\AnonymousNotifiable;
+
+test('invitation notification contains accept url', function () {
+    $user = User::factory()->withTeam()->create();
+    $invitation = TeamInvitation::factory()->for($user->currentTeam)->create(['email' => 'test@example.com']);
+
+    $mail = new TeamInvitationNotification($invitation)->toMail(new AnonymousNotifiable);
+
+    expect($mail->actionUrl)->toContain('team-invitations/' . $invitation->id . '/accept');
+});

--- a/tests/Unit/Notifications/TeamInvitationNotificationTest.php
+++ b/tests/Unit/Notifications/TeamInvitationNotificationTest.php
@@ -11,5 +11,5 @@ test('invitation notification contains accept url', function () {
 
     $mail = new TeamInvitationNotification($invitation)->toMail(new AnonymousNotifiable);
 
-    expect($mail->actionUrl)->toContain('team-invitations/' . $invitation->id . '/accept');
+    expect($mail->actionUrl)->toContain('invitations/' . $invitation->id . '/accept');
 });


### PR DESCRIPTION
This pull request introduces a complete team management and invitation system, including backend logic, validation, notifications, and user interface updates. The changes allow team owners to invite members, send and accept invitations, enforce email matching, and manage teams through new settings pages. The most important changes are grouped below.

**Team Invitation and Joining Logic**

- Added `InviteTeamMember` and `JoinTeam` action classes to handle sending invitations via email and accepting them, including transactional logic and validation to ensure only the invited user can join a team. [[1]](diffhunk://#diff-f077cffdfa42c8758daf8199de59f0e8baf07bb9f170bc73b7344def14908457R1-R23) [[2]](diffhunk://#diff-eac03ee5d278e3aba14b9bbe982413cf0dac4e0ff2d9b2b6e82fb4d46766085eR1-R31)
- Implemented `TeamInvitationNotification` to send signed invitation links to users, with expiration and clear messaging.
- Added `AcceptTeamInvitation` controller to handle invitation links, redirecting users to login or registration as appropriate, and storing the invitation in the session for later acceptance.
- Created an event listener `AcceptPendingInvitation` to process pending invitations upon user login.

**Validation and Security**

- Introduced `InvitationEmailMatch` validation rule to ensure the email used during login or registration matches the invitation, and applied it to relevant validation rules and request classes. [[1]](diffhunk://#diff-47af6d64b3bcf579dca470a46f0d97a992a4206e60a572ccbb265ff9f3526c20R1-R29) [[2]](diffhunk://#diff-04b2761fab14683229d2d5c3c23925f01b1054b9fd09ae969657cf0d413b24a7R39) [[3]](diffhunk://#diff-88ac1e2ea7ead10cb568b0945d3ef02f363e54043f1c94e034a591b2c835566fR1-R21)
- Updated `ProfileValidationRules` and `PasswordValidationRules` to use concise docblocks and proper imports. [[1]](diffhunk://#diff-04b2761fab14683229d2d5c3c23925f01b1054b9fd09ae969657cf0d413b24a7R8-R13) [[2]](diffhunk://#diff-04b2761fab14683229d2d5c3c23925f01b1054b9fd09ae969657cf0d413b24a7L25-R28) [[3]](diffhunk://#diff-35ad201bc43c5911028c05862393b124fb6fc9f4a942bbc8ed3e04d2df6c8b79L7-R18)

**Fortify Integration**

- Bound the custom `LoginRequest` to replace Fortify's default, integrating the invitation email check into the login process.

**User Interface and Routing**

- Added a new Team Settings page (`⚡team.blade.php`) with Livewire component logic for inviting members, cancelling invitations, updating team names, and listing members/invitations.
- Updated navigation in layout and settings views to show team management links only to team owners. [[1]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7R15-R19) [[2]](diffhunk://#diff-873b6565a0af044b0ac776eeb4fdb65ce3d34d902a86b291c9a444b8049ea4faR5-R7)
- Registered the new team settings route and invitation acceptance route. [[1]](diffhunk://#diff-ee9e3b37700a7db98ab6bc31ae169b868c13ef5090e8b317261de74caf521fb3R10) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR3)