### PR TITLE
Add public recipe sharing

### DIFF
--- a/app/Models/Recipe.php
+++ b/app/Models/Recipe.php
@@ -27,6 +27,7 @@ class Recipe extends Model implements HasMedia
         'parent_id',
         'name',
         'slug',
+        'share_token',
         'source',
         'servings',
         'prep_time',
@@ -111,5 +112,29 @@ class Recipe extends Model implements HasMedia
     public function isSourceUrl(): bool
     {
         return filter_var($this->source, FILTER_VALIDATE_URL) !== false;
+    }
+
+    public function enableSharing(): void
+    {
+        $this->update(['share_token' => Str::uuid()->toString()]);
+    }
+
+    public function disableSharing(): void
+    {
+        $this->update(['share_token' => null]);
+    }
+
+    public function isShared(): bool
+    {
+        return ! is_null($this->share_token);
+    }
+
+    /** @return array<string, mixed> */
+    public function toRecipeData(): array
+    {
+        return $this->only([
+            'name', 'source', 'servings', 'prep_time', 'cook_time', 'total_time',
+            'description', 'ingredients', 'instructions', 'notes', 'nutrition',
+        ]);
     }
 }

--- a/app/Models/Recipe.php
+++ b/app/Models/Recipe.php
@@ -128,13 +128,4 @@ class Recipe extends Model implements HasMedia
     {
         return ! is_null($this->share_token);
     }
-
-    /** @return array<string, mixed> */
-    public function toRecipeData(): array
-    {
-        return $this->only([
-            'name', 'source', 'servings', 'prep_time', 'cook_time', 'total_time',
-            'description', 'ingredients', 'instructions', 'notes', 'nutrition',
-        ]);
-    }
 }

--- a/app/Policies/RecipePolicy.php
+++ b/app/Policies/RecipePolicy.php
@@ -38,4 +38,9 @@ class RecipePolicy
     {
         return $recipe->team_id === $user->current_team_id;
     }
+
+    public function share(User $user, Recipe $recipe): bool
+    {
+        return $recipe->team_id === $user->current_team_id;
+    }
 }

--- a/database/factories/RecipeFactory.php
+++ b/database/factories/RecipeFactory.php
@@ -34,6 +34,13 @@ class RecipeFactory extends Factory
         });
     }
 
+    public function shared(): static
+    {
+        return $this->state(fn () => [
+            'share_token' => Str::uuid()->toString(),
+        ]);
+    }
+
     public function remixOf(Recipe $parent): static
     {
         return $this->state(fn () => [

--- a/database/migrations/2026_03_04_180745_add_share_token_to_recipes_table.php
+++ b/database/migrations/2026_03_04_180745_add_share_token_to_recipes_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->string('share_token')->nullable()->unique()->after('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->dropColumn('share_token');
+        });
+    }
+};

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+    <head>
+        @include('layouts.partials.head')
+    </head>
+    <body class="min-h-screen bg-white antialiased dark:bg-zinc-800">
+        <div class="mx-auto max-w-4xl px-6 py-10">
+            <div class="mb-8 flex items-center gap-3">
+                <a href="{{ route('home') }}">
+                    <flux:avatar :src="asset('icon.png')" />
+                </a>
+                <flux:heading size="lg">{{ config('app.name') }}</flux:heading>
+            </div>
+
+            {{ $slot }}
+        </div>
+
+        @persist('toast')
+            <flux:toast />
+        @endpersist
+
+        @fluxScripts
+    </body>
+</html>

--- a/resources/views/pages/recipes/detail.blade.php
+++ b/resources/views/pages/recipes/detail.blade.php
@@ -1,0 +1,115 @@
+<div class="grid gap-6 lg:grid-cols-3">
+    <div class="space-y-6 lg:col-span-2">
+        @if ($recipe->description)
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Description') }}</flux:heading>
+                <flux:text>{{ $recipe->description }}</flux:text>
+            </flux:card>
+        @endif
+
+        @if ($recipe->ingredients)
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Ingredients') }}</flux:heading>
+                <x-prose :content="$recipe->ingredients" />
+            </flux:card>
+        @endif
+
+        @if ($recipe->instructions)
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Instructions') }}</flux:heading>
+                <x-prose :content="$recipe->instructions" />
+            </flux:card>
+        @endif
+
+        @if ($recipe->notes)
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Notes') }}</flux:heading>
+                <flux:text>{{ $recipe->notes }}</flux:text>
+            </flux:card>
+        @endif
+    </div>
+
+    <div class="space-y-6">
+        <flux:card>
+            <flux:heading size="lg" class="mb-4">{{ __('Details') }}</flux:heading>
+
+            <dl class="space-y-4">
+                @if ($recipe->source)
+                    <div>
+                        <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Source') }}</dt>
+                        <dd class="mt-1">
+                            @if ($recipe->isSourceUrl())
+                                <flux:link href="{{ $recipe->source }}" target="_blank">
+                                    {{ $recipe->shortenedSource() }}
+                                </flux:link>
+                            @else
+                                {{ $recipe->source }}
+                            @endif
+                        </dd>
+                    </div>
+                @endif
+
+                @if ($recipe->servings)
+                    <div>
+                        <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Servings') }}</dt>
+                        <dd class="mt-1">{{ $recipe->servings }}</dd>
+                    </div>
+                @endif
+
+                @if ($recipe->prep_time)
+                    <div>
+                        <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Prep Time') }}</dt>
+                        <dd class="mt-1">{{ $recipe->prep_time }}</dd>
+                    </div>
+                @endif
+
+                @if ($recipe->cook_time)
+                    <div>
+                        <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Cook Time') }}</dt>
+                        <dd class="mt-1">{{ $recipe->cook_time }}</dd>
+                    </div>
+                @endif
+
+                @if ($recipe->total_time)
+                    <div>
+                        <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Total Time') }}</dt>
+                        <dd class="mt-1">{{ $recipe->total_time }}</dd>
+                    </div>
+                @endif
+            </dl>
+        </flux:card>
+
+        @if ($recipe->nutrition)
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Nutrition') }}</flux:heading>
+                <div class="prose dark:prose-invert">
+                    {!! nl2br(e($recipe->nutrition)) !!}
+                </div>
+            </flux:card>
+        @endif
+
+        @if ($recipe->parent)
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Remixed From') }}</flux:heading>
+                <flux:link href="{{ route('recipes.show', $recipe->parent) }}" wire:navigate>
+                    {{ $recipe->parent->name }}
+                </flux:link>
+            </flux:card>
+        @endif
+
+        @if ($recipe->remixes->isNotEmpty())
+            <flux:card>
+                <flux:heading size="lg" class="mb-2">{{ __('Remixes') }}</flux:heading>
+                <ul class="list-disc ml-4 space-y-1">
+                    @foreach ($recipe->remixes as $remix)
+                    <li>
+                        <flux:link href="{{ route('recipes.show', $remix) }}" wire:navigate>
+                            {{ $remix->name }}
+                        </flux:link>
+                    </li>
+                    @endforeach
+                </ul>
+            </flux:card>
+        @endif
+    </div>
+</div>

--- a/resources/views/pages/recipes/⚡shared.blade.php
+++ b/resources/views/pages/recipes/⚡shared.blade.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Actions\CreateRecipe;
+use App\Models\Recipe;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+new #[Layout('layouts::guest')] class extends Component {
+    public Recipe $recipe;
+
+    public function mount(string $shareToken): void
+    {
+        $this->recipe = Recipe::where('share_token', $shareToken)->firstOrFail();
+    }
+
+    #[Computed]
+    public function existingRecipe(): ?Recipe
+    {
+        if (! Auth::check()) {
+            return null;
+        }
+
+        $team = Auth::user()->currentTeam;
+
+        if ($this->recipe->team_id === $team->id) {
+            return $this->recipe;
+        }
+
+        return Recipe::where('team_id', $team->id)
+            ->where('source', route('recipes.shared', $this->recipe->share_token))
+            ->first();
+    }
+
+    public function addToMyTeam(): void
+    {
+        if (! Auth::check()) {
+            $this->redirect(route('login'));
+
+            return;
+        }
+
+        $team = Auth::user()->currentTeam;
+        $shareUrl = route('recipes.shared', $this->recipe->share_token);
+
+        if ($this->recipe->team_id === $team->id) {
+            $this->redirect(route('recipes.show', $this->recipe), navigate: true);
+
+            return;
+        }
+
+        $existing = Recipe::where('team_id', $team->id)->where('source', $shareUrl)->first();
+
+        if ($existing) {
+            $this->redirect(route('recipes.show', $existing), navigate: true);
+
+            return;
+        }
+
+        $data = [
+            ...$this->recipe->toRecipeData(),
+            'source' => $shareUrl,
+        ];
+
+        $recipe = (new CreateRecipe)->handle($team, $data);
+
+        $this->redirect(route('recipes.show', $recipe), navigate: true);
+    }
+}; ?>
+
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <flux:heading size="xl">{{ $recipe->name }}</flux:heading>
+
+        @auth
+            @if ($this->existingRecipe)
+                <flux:button :href="route('recipes.show', $this->existingRecipe)" icon="arrow-right" wire:navigate>{{ __('Already in My Recipes') }}</flux:button>
+            @else
+                <flux:button wire:click="addToMyTeam" icon="plus">{{ __('Add to My Team') }}</flux:button>
+            @endif
+        @endauth
+    </div>
+
+    @include('pages.recipes.detail')
+</div>

--- a/resources/views/pages/recipes/⚡shared.blade.php
+++ b/resources/views/pages/recipes/⚡shared.blade.php
@@ -3,7 +3,6 @@
 use App\Actions\CreateRecipe;
 use App\Models\Recipe;
 use Illuminate\Support\Facades\Auth;
-use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -15,55 +14,33 @@ new #[Layout('layouts::guest')] class extends Component {
         $this->recipe = Recipe::where('share_token', $shareToken)->firstOrFail();
     }
 
-    #[Computed]
-    public function existingRecipe(): ?Recipe
-    {
-        if (! Auth::check()) {
-            return null;
-        }
-
-        $team = Auth::user()->currentTeam;
-
-        if ($this->recipe->team_id === $team->id) {
-            return $this->recipe;
-        }
-
-        return Recipe::where('team_id', $team->id)
-            ->where('source', route('recipes.shared', $this->recipe->share_token))
-            ->first();
-    }
-
     public function addToMyTeam(): void
     {
+        $source = route('recipes.shared', $this->recipe->share_token);
+
         if (! Auth::check()) {
             $this->redirect(route('login'));
 
             return;
-        }
-
-        $team = Auth::user()->currentTeam;
-        $shareUrl = route('recipes.shared', $this->recipe->share_token);
-
-        if ($this->recipe->team_id === $team->id) {
+        // check if user is owner of recipe
+        } else if ($this->recipe->team_id === Auth::user()->current_team_id) {
             $this->redirect(route('recipes.show', $this->recipe), navigate: true);
 
             return;
-        }
-
-        $existing = Recipe::where('team_id', $team->id)->where('source', $shareUrl)->first();
-
-        if ($existing) {
-            $this->redirect(route('recipes.show', $existing), navigate: true);
+        // check if user already saved it
+        } else if ($toRecipe = Auth::user()->currentTeam->recipes()->where('source', $source)->first()) {
+            $this->redirect(route('recipes.show', $toRecipe), navigate: true);
 
             return;
         }
 
-        $data = [
-            ...$this->recipe->toRecipeData(),
-            'source' => $shareUrl,
-        ];
-
-        $recipe = (new CreateRecipe)->handle($team, $data);
+        $recipe = (new CreateRecipe)->handle(Auth::user()->currentTeam, [
+            ...$this->recipe->only([
+                'name', 'source', 'servings', 'prep_time', 'cook_time', 'total_time',
+                'description', 'ingredients', 'instructions', 'notes', 'nutrition',
+            ]),
+            'source' => $source,
+        ]);
 
         $this->redirect(route('recipes.show', $recipe), navigate: true);
     }
@@ -74,11 +51,7 @@ new #[Layout('layouts::guest')] class extends Component {
         <flux:heading size="xl">{{ $recipe->name }}</flux:heading>
 
         @auth
-            @if ($this->existingRecipe)
-                <flux:button :href="route('recipes.show', $this->existingRecipe)" icon="arrow-right" wire:navigate>{{ __('Already in My Recipes') }}</flux:button>
-            @else
-                <flux:button wire:click="addToMyTeam" icon="plus">{{ __('Add to My Team') }}</flux:button>
-            @endif
+            <flux:button wire:click="addToMyTeam" icon="plus" :disabled="Auth::user()->current_team_id === $recipe->team_id">{{ __('Add to My Team') }}</flux:button>
         @endauth
     </div>
 

--- a/resources/views/pages/recipes/⚡shared.test.php
+++ b/resources/views/pages/recipes/⚡shared.test.php
@@ -59,46 +59,45 @@ test('adding shared recipe to team creates a copy', function () {
 
     $user = User::factory()->withTeam()->create();
 
-    $this->actingAs($user);
-
-    Livewire::test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
+    Livewire::actingAs($user)
+        ->test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
         ->call('addToMyTeam')
         ->assertRedirect();
 
-    $copy = Recipe::where('team_id', $user->currentTeam->id)->first();
-
-    expect($copy)->not->toBeNull()
-        ->and($copy->name)->toBe('Shared Pasta')
-        ->and($copy->description)->toBe('A nice pasta recipe')
-        ->and($copy->servings)->toBe('4')
-        ->and($copy->source)->toBe(route('recipes.shared', $recipe->share_token))
-        ->and($copy->share_token)->toBeNull();
+    expect(Recipe::firstWhere('team_id', $user->currentTeam->id))->not->toBeNull()
+        ->name->toBe('Shared Pasta')
+        ->description->toBe('A nice pasta recipe')
+        ->servings->toBe('4')
+        ->source->toBe(route('recipes.shared', $recipe->share_token))
+        ->share_token->toBeNull();
 });
 
-test('owner sees already in my recipes instead of add button', function () {
+test('owner sees disabled add button', function () {
     $user = User::factory()->withTeam()->create();
     $recipe = Recipe::factory()->shared()->for($user->currentTeam)->create();
 
     $this->actingAs($user)
         ->get(route('recipes.shared', $recipe->share_token))
         ->assertOk()
-        ->assertSee('Already in My Recipes')
-        ->assertDontSee('Add to My Team');
+        ->assertSeeHtml('wire:click="addToMyTeam" disabled');
 });
 
-test('previously added recipe shows already in my recipes', function () {
+test('previously added recipe shows view in my recipes', function () {
     $recipe = Recipe::factory()->shared()->create(['name' => 'Shared Pasta']);
     $user = User::factory()->withTeam()->create();
 
-    Recipe::factory()->for($user->currentTeam)->create([
+    $copy = Recipe::factory()->for($user->currentTeam)->create([
         'source' => route('recipes.shared', $recipe->share_token),
     ]);
 
-    $this->actingAs($user)
-        ->get(route('recipes.shared', $recipe->share_token))
+    Livewire::actingAs($user)
+        ->test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
         ->assertOk()
-        ->assertSee('Already in My Recipes')
-        ->assertDontSee('Add to My Team');
+        ->assertSee('Add to My Team')
+        ->call('addToMyTeam')
+        ->assertRedirect(route('recipes.show', ['recipe' => $copy]));
+
+    expect(Recipe::where('team_id', $user->currentTeam->id)->where('source', route('recipes.shared', $recipe->share_token))->count())->toBe(1);
 });
 
 test('adding recipe that already exists redirects to existing', function () {
@@ -109,9 +108,8 @@ test('adding recipe that already exists redirects to existing', function () {
         'source' => route('recipes.shared', $recipe->share_token),
     ]);
 
-    $this->actingAs($user);
-
-    Livewire::test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
+    Livewire::actingAs($user)
+        ->test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
         ->call('addToMyTeam')
         ->assertRedirect(route('recipes.show', $existing));
 

--- a/resources/views/pages/recipes/⚡shared.test.php
+++ b/resources/views/pages/recipes/⚡shared.test.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Models\Recipe;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('shared recipe is viewable without authentication', function () {
+    $recipe = Recipe::factory()->shared()->create(['name' => 'Test Recipe']);
+
+    $this->get(route('recipes.shared', $recipe->share_token))
+        ->assertOk()
+        ->assertSee('Test Recipe');
+});
+
+test('invalid share token returns 404', function () {
+    $this->get(route('recipes.shared', 'nonexistent-token'))
+        ->assertNotFound();
+});
+
+test('unshared recipe is not publicly accessible', function () {
+    $recipe = Recipe::factory()->create();
+
+    expect($recipe->share_token)->toBeNull();
+
+    $this->get('/recipes/shared/null')
+        ->assertNotFound();
+});
+
+test('authenticated user can add shared recipe to their team', function () {
+    $recipe = Recipe::factory()->shared()->create([
+        'name' => 'Grandma Cookies',
+        'description' => 'Delicious cookies',
+        'ingredients' => '<ul><li>Flour</li></ul>',
+        'instructions' => '<ol><li>Mix</li></ol>',
+    ]);
+
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user)
+        ->get(route('recipes.shared', $recipe->share_token))
+        ->assertOk()
+        ->assertSee('Add to My Team');
+});
+
+test('guest does not see add to my team button', function () {
+    $recipe = Recipe::factory()->shared()->create();
+
+    $this->get(route('recipes.shared', $recipe->share_token))
+        ->assertOk()
+        ->assertDontSee('Add to My Team');
+});
+
+test('adding shared recipe to team creates a copy', function () {
+    $recipe = Recipe::factory()->shared()->create([
+        'name' => 'Shared Pasta',
+        'description' => 'A nice pasta recipe',
+        'servings' => '4',
+    ]);
+
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
+        ->call('addToMyTeam')
+        ->assertRedirect();
+
+    $copy = Recipe::where('team_id', $user->currentTeam->id)->first();
+
+    expect($copy)->not->toBeNull()
+        ->and($copy->name)->toBe('Shared Pasta')
+        ->and($copy->description)->toBe('A nice pasta recipe')
+        ->and($copy->servings)->toBe('4')
+        ->and($copy->source)->toBe(route('recipes.shared', $recipe->share_token))
+        ->and($copy->share_token)->toBeNull();
+});
+
+test('owner sees already in my recipes instead of add button', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->shared()->for($user->currentTeam)->create();
+
+    $this->actingAs($user)
+        ->get(route('recipes.shared', $recipe->share_token))
+        ->assertOk()
+        ->assertSee('Already in My Recipes')
+        ->assertDontSee('Add to My Team');
+});
+
+test('previously added recipe shows already in my recipes', function () {
+    $recipe = Recipe::factory()->shared()->create(['name' => 'Shared Pasta']);
+    $user = User::factory()->withTeam()->create();
+
+    Recipe::factory()->for($user->currentTeam)->create([
+        'source' => route('recipes.shared', $recipe->share_token),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('recipes.shared', $recipe->share_token))
+        ->assertOk()
+        ->assertSee('Already in My Recipes')
+        ->assertDontSee('Add to My Team');
+});
+
+test('adding recipe that already exists redirects to existing', function () {
+    $recipe = Recipe::factory()->shared()->create(['name' => 'Shared Pasta']);
+    $user = User::factory()->withTeam()->create();
+
+    $existing = Recipe::factory()->for($user->currentTeam)->create([
+        'source' => route('recipes.shared', $recipe->share_token),
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::recipes.shared', ['shareToken' => $recipe->share_token])
+        ->call('addToMyTeam')
+        ->assertRedirect(route('recipes.show', $existing));
+
+    expect(Recipe::where('team_id', $user->currentTeam->id)->count())->toBe(1);
+});

--- a/resources/views/pages/recipes/⚡show.blade.php
+++ b/resources/views/pages/recipes/⚡show.blade.php
@@ -15,6 +15,19 @@ new class extends Component {
 
         $this->redirect(route('recipes.show', $recipe), navigate: true);
     }
+
+    public function toggleSharing(): void
+    {
+        $this->authorize('share', $this->recipe);
+
+        if ($this->recipe->isShared()) {
+            $this->recipe->disableSharing();
+        } else {
+            $this->recipe->enableSharing();
+        }
+
+        $this->recipe->refresh();
+    }
 }; ?>
 
 <div class="space-y-6">
@@ -24,124 +37,34 @@ new class extends Component {
             <flux:heading size="xl">{{ $recipe->name }}</flux:heading>
         </div>
         <div class="flex gap-2">
+            <flux:dropdown align="end">
+                <flux:button icon="share" :variant="$recipe->isShared() ? 'primary' : 'filled'">{{ __('Share') }}</flux:button>
+                <flux:popover class="w-80">
+                    <div class="space-y-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <flux:heading size="sm">{{ __('Public Link') }}</flux:heading>
+                                <flux:text size="sm">{{ __('Anyone with the link can view this recipe.') }}</flux:text>
+                            </div>
+                            <flux:switch wire:click="toggleSharing" :checked="$recipe->isShared()" />
+                        </div>
+
+                        @if ($recipe->isShared())
+                            <div x-data="{ copied: false }">
+                                <flux:input
+                                    readonly
+                                    :value="route('recipes.shared', $recipe->share_token)"
+                                    copyable
+                                />
+                            </div>
+                        @endif
+                    </div>
+                </flux:popover>
+            </flux:dropdown>
             <flux:button wire:click="remix" icon="document-duplicate">{{ __('Remix') }}</flux:button>
             <flux:button :href="route('recipes.edit', $recipe)" icon="pencil" wire:navigate>{{ __('Edit') }}</flux:button>
         </div>
     </div>
 
-    <div class="grid gap-6 lg:grid-cols-3">
-        <div class="space-y-6 lg:col-span-2">
-            @if ($recipe->description)
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Description') }}</flux:heading>
-                    <flux:text>{{ $recipe->description }}</flux:text>
-                </flux:card>
-            @endif
-
-            @if ($recipe->ingredients)
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Ingredients') }}</flux:heading>
-                    <x-prose :content="$recipe->ingredients" />
-                </flux:card>
-            @endif
-
-            @if ($recipe->instructions)
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Instructions') }}</flux:heading>
-                    <x-prose :content="$recipe->instructions" />
-                </flux:card>
-            @endif
-
-            @if ($recipe->notes)
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Notes') }}</flux:heading>
-                    <flux:text>{{ $recipe->notes }}</flux:text>
-                </flux:card>
-            @endif
-        </div>
-
-        <div class="space-y-6">
-            <flux:card>
-                <flux:heading size="lg" class="mb-4">{{ __('Details') }}</flux:heading>
-
-                <dl class="space-y-4">
-                    @if ($recipe->source)
-                        <div>
-                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Source') }}</dt>
-                            <dd class="mt-1">
-                                @if ($recipe->isSourceUrl())
-                                    <flux:link href="{{ $recipe->source }}" target="_blank">
-                                        {{ $recipe->shortenedSource() }}
-                                    </flux:link>
-                                @else
-                                    {{ $recipe->source }}
-                                @endif
-                            </dd>
-                        </div>
-                    @endif
-
-                    @if ($recipe->servings)
-                        <div>
-                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Servings') }}</dt>
-                            <dd class="mt-1">{{ $recipe->servings }}</dd>
-                        </div>
-                    @endif
-
-                    @if ($recipe->prep_time)
-                        <div>
-                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Prep Time') }}</dt>
-                            <dd class="mt-1">{{ $recipe->prep_time }}</dd>
-                        </div>
-                    @endif
-
-                    @if ($recipe->cook_time)
-                        <div>
-                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Cook Time') }}</dt>
-                            <dd class="mt-1">{{ $recipe->cook_time }}</dd>
-                        </div>
-                    @endif
-
-                    @if ($recipe->total_time)
-                        <div>
-                            <dt class="text-sm font-medium text-zinc-500 dark:text-zinc-400">{{ __('Total Time') }}</dt>
-                            <dd class="mt-1">{{ $recipe->total_time }}</dd>
-                        </div>
-                    @endif
-                </dl>
-            </flux:card>
-
-            @if ($recipe->nutrition)
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Nutrition') }}</flux:heading>
-                    <div class="prose dark:prose-invert">
-                        {!! nl2br(e($recipe->nutrition)) !!}
-                    </div>
-                </flux:card>
-            @endif
-
-            @if ($recipe->parent)
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Remixed From') }}</flux:heading>
-                    <flux:link href="{{ route('recipes.show', $recipe->parent) }}" wire:navigate>
-                        {{ $recipe->parent->name }}
-                    </flux:link>
-                </flux:card>
-            @endif
-
-            @if ($recipe->remixes->isNotEmpty())
-                <flux:card>
-                    <flux:heading size="lg" class="mb-2">{{ __('Remixes') }}</flux:heading>
-                    <ul class="list-disc ml-4 space-y-1">
-                        @foreach ($recipe->remixes as $remix)
-                        <li>
-                            <flux:link href="{{ route('recipes.show', $remix) }}" wire:navigate>
-                                {{ $remix->name }}
-                            </flux:link>
-                        </li>
-                        @endforeach
-                    </ul>
-                </flux:card>
-            @endif
-        </div>
-    </div>
+    @include('pages.recipes.detail')
 </div>

--- a/resources/views/pages/recipes/⚡show.test.php
+++ b/resources/views/pages/recipes/⚡show.test.php
@@ -70,3 +70,31 @@ test('parent shows remixes', function () {
         ->assertSee('Remixes')
         ->assertSee('Remixed Recipe');
 });
+
+test('owner can toggle sharing on recipe show page', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->create(['team_id' => $user->currentTeam->id]);
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::recipes.show', ['recipe' => $recipe])
+        ->call('toggleSharing');
+
+    expect($recipe->fresh()->isShared())->toBeTrue();
+
+    Livewire::test('pages::recipes.show', ['recipe' => $recipe])
+        ->call('toggleSharing');
+
+    expect($recipe->fresh()->isShared())->toBeFalse();
+});
+
+test('non-owner cannot toggle sharing', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->create();
+
+    $this->actingAs($user);
+
+    Livewire::test('pages::recipes.show', ['recipe' => $recipe])
+        ->call('toggleSharing')
+        ->assertForbidden();
+});

--- a/routes/recipes.php
+++ b/routes/recipes.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 
+Route::livewire('recipes/shared/{shareToken}', 'pages::recipes.shared')->name('recipes.shared');
+
 Route::middleware(['auth', 'verified'])->prefix('recipes')->name('recipes')->group(function () {
     Route::livewire('/', 'pages::recipes.index')->name('.index')->middleware('can:viewAny,App\Models\Recipe');
     Route::livewire('create', 'pages::recipes.create')->name('.create')->middleware('can:create,App\Models\Recipe');

--- a/tests/Unit/Models/RecipeTest.php
+++ b/tests/Unit/Models/RecipeTest.php
@@ -99,3 +99,25 @@ test('source can be shortened', function () {
 
     expect($recipe->shortenedSource())->toBe('italianfoodforever.com');
 });
+
+test('enabling sharing generates a share token', function () {
+    $recipe = Recipe::factory()->create();
+
+    expect($recipe->isShared())->toBeFalse();
+
+    $recipe->enableSharing();
+
+    expect($recipe->isShared())->toBeTrue()
+        ->and($recipe->share_token)->not->toBeNull();
+});
+
+test('disabling sharing removes the share token', function () {
+    $recipe = Recipe::factory()->shared()->create();
+
+    expect($recipe->isShared())->toBeTrue();
+
+    $recipe->disableSharing();
+
+    expect($recipe->isShared())->toBeFalse()
+        ->and($recipe->share_token)->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Users can toggle a shareable public link on any recipe via a Share button on the show page
- Anyone with the link can view the recipe without logging in (served on a minimal guest layout)
- Authenticated visitors see an "Add to My Team" button that copies the recipe into their team
- Duplicate detection prevents re-adding the same shared recipe, showing "Already in My Recipes" instead

## Changes
- Migration adding `share_token` column to recipes table
- `Recipe` model: `enableSharing()`, `disableSharing()`, `isShared()`, `toRecipeData()` methods
- `RecipePolicy`: new `share` authorization method
- Public route `/recipes/shared/{shareToken}` (no auth required)
- New `⚡shared.blade.php` Livewire page with `existingRecipe` computed property for duplicate detection
- Extracted shared recipe markup into `detail.blade.php` partial (used by both show and shared pages)
- New `guest.blade.php` layout for public pages
- Recipe factory `shared()` state
- Co-located tests for shared page, plus additions to show and model tests