### PR TITLE
Recipe API

### DIFF
--- a/app/Http/Controllers/Api/RecipeController.php
+++ b/app/Http/Controllers/Api/RecipeController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Actions\CreateRecipe;
+use App\Actions\DeleteRecipe;
+use App\Actions\UpdateRecipe;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreRecipeRequest;
+use App\Http\Requests\Api\UpdateRecipeRequest;
+use App\Http\Resources\RecipeResource;
+use App\Models\Recipe;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+
+class RecipeController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        Gate::authorize('viewAny', Recipe::class);
+
+        $recipes = Auth::user()->currentTeam->recipes()->latest()->get();
+
+        return RecipeResource::collection($recipes);
+    }
+
+    public function store(StoreRecipeRequest $request, CreateRecipe $action): JsonResponse
+    {
+        $recipe = $action->handle(Auth::user()->currentTeam, $request->validated());
+
+        return RecipeResource::make($recipe)
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function show(Recipe $recipe): RecipeResource
+    {
+        Gate::authorize('view', $recipe);
+
+        return RecipeResource::make($recipe);
+    }
+
+    public function update(UpdateRecipeRequest $request, Recipe $recipe, UpdateRecipe $action): RecipeResource
+    {
+        $recipe = $action->handle($recipe, $request->validated());
+
+        return RecipeResource::make($recipe);
+    }
+
+    public function destroy(Recipe $recipe, DeleteRecipe $action): Response
+    {
+        Gate::authorize('delete', $recipe);
+
+        $action->handle($recipe);
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/StoreRecipeRequest.php
+++ b/app/Http/Requests/Api/StoreRecipeRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use App\Models\Recipe;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class StoreRecipeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return Gate::allows('create', Recipe::class);
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'source' => ['nullable', 'string', 'max:500'],
+            'servings' => ['nullable', 'string', 'max:50'],
+            'prep_time' => ['nullable', 'string', 'max:50'],
+            'cook_time' => ['nullable', 'string', 'max:50'],
+            'total_time' => ['nullable', 'string', 'max:50'],
+            'description' => ['nullable', 'string'],
+            'ingredients' => ['nullable', 'string'],
+            'instructions' => ['nullable', 'string'],
+            'notes' => ['nullable', 'string'],
+            'nutrition' => ['nullable', 'string'],
+            'parent_id' => ['nullable', 'integer', 'exists:recipes,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/UpdateRecipeRequest.php
+++ b/app/Http/Requests/Api/UpdateRecipeRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class UpdateRecipeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return Gate::allows('update', $this->route('recipe'));
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'source' => ['nullable', 'string', 'max:500'],
+            'servings' => ['nullable', 'string', 'max:50'],
+            'prep_time' => ['nullable', 'string', 'max:50'],
+            'cook_time' => ['nullable', 'string', 'max:50'],
+            'total_time' => ['nullable', 'string', 'max:50'],
+            'description' => ['nullable', 'string'],
+            'ingredients' => ['nullable', 'string'],
+            'instructions' => ['nullable', 'string'],
+            'notes' => ['nullable', 'string'],
+            'nutrition' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class RecipeResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "dedoc/scramble": "^0.13.14",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^12.0",
         "laravel/nightwatch": "^1.24",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e75044fba72ff5d28bafb1712ce040e1",
+    "content-hash": "56e1e773e3bd8f4c67efd6ede69329c0",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -467,6 +467,86 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "dedoc/scramble",
+            "version": "v0.13.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dedoc/scramble.git",
+                "reference": "8f0c1bba364e4916f3f2ff23b7f4ca002e586b75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dedoc/scramble/zipball/8f0c1bba364e4916f3f2ff23b7f4ca002e586b75",
+                "reference": "8f0c1bba364e4916f3f2ff23b7f4ca002e586b75",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "myclabs/deep-copy": "^1.12",
+                "nikic/php-parser": "^5.0",
+                "php": "^8.1",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "spatie/laravel-package-tools": "^1.9.2"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.3",
+                "laravel/pint": "^v1.1.0",
+                "nunomaduro/collision": "^7.0|^8.0",
+                "orchestra/testbench": "^8.0|^9.0|^10.0",
+                "pestphp/pest": "^2.34|^3.7",
+                "pestphp/pest-plugin-laravel": "^2.3|^3.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5|^11.5.3",
+                "spatie/laravel-permission": "^6.10",
+                "spatie/pest-plugin-snapshots": "^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Dedoc\\Scramble\\ScrambleServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dedoc\\Scramble\\": "src",
+                    "Dedoc\\Scramble\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Lytvynenko",
+                    "email": "litvinenko95@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatic generation of API documentation for Laravel applications.",
+            "homepage": "https://github.com/dedoc/scramble",
+            "keywords": [
+                "documentation",
+                "laravel",
+                "openapi"
+            ],
+            "support": {
+                "issues": "https://github.com/dedoc/scramble/issues",
+                "source": "https://github.com/dedoc/scramble/tree/v0.13.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/romalytvynenko",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-15T13:14:31+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3090,6 +3170,66 @@
             "time": "2024-09-04T18:46:31+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "3.11.1",
             "source": {
@@ -3718,6 +3858,53 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -10209,66 +10396,6 @@
             "time": "2024-05-16T03:13:13+00:00"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.13.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpspec/prophecy": "^1.10",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
             "name": "nunomaduro/collision",
             "version": "v8.9.1",
             "source": {
@@ -11202,53 +11329,6 @@
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
             "time": "2026-01-06T21:53:42+00:00"
-        },
-        {
-            "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^5.3.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
-            },
-            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,15 @@
 <?php
 
+use App\Http\Controllers\Api\RecipeController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::get('user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
+Route::middleware('auth:sanctum')->name('api.')->group(function () {
+    Route::get('user', fn (Request $request) => $request->user())->name('user');
+
+    Route::get('recipes', [RecipeController::class, 'index'])->name('recipes.index');
+    Route::post('recipes', [RecipeController::class, 'store'])->name('recipes.store');
+    Route::get('recipes/{recipe}', [RecipeController::class, 'show'])->name('recipes.show');
+    Route::patch('recipes/{recipe}', [RecipeController::class, 'update'])->name('recipes.update');
+    Route::delete('recipes/{recipe}', [RecipeController::class, 'destroy'])->name('recipes.destroy');
+});

--- a/tests/Feature/Api/RecipeControllerTest.php
+++ b/tests/Feature/Api/RecipeControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Models\Recipe;
+use App\Models\User;
+
+test('guests cannot access recipes', function () {
+    $this->getJson(route('api.recipes.index'))->assertUnauthorized();
+    $this->postJson(route('api.recipes.store'))->assertUnauthorized();
+    $this->getJson(route('api.recipes.show', 1))->assertUnauthorized();
+    $this->patchJson(route('api.recipes.update', 1))->assertUnauthorized();
+    $this->deleteJson(route('api.recipes.destroy', 1))->assertUnauthorized();
+});
+
+test('index returns recipes for the current team', function () {
+    $user = User::factory()->withTeam()->create();
+    Recipe::factory()->for($user->currentTeam)->count(3)->create();
+    Recipe::factory()->count(2)->create();
+
+    $this->actingAs($user)
+        ->getJson(route('api.recipes.index'))
+        ->assertOk()
+        ->assertJsonCount(3, 'data')
+        ->assertJsonStructure(['data' => [['id', 'name', 'slug']]]);
+});
+
+test('store creates a recipe and returns it', function () {
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('api.recipes.store'), [
+            'name' => 'Chocolate Cake',
+            'servings' => '8',
+            'prep_time' => '20 minutes',
+            'cook_time' => '45 minutes',
+        ])
+        ->assertCreated()
+        ->assertJsonPath('data.name', 'Chocolate Cake')
+        ->assertJsonPath('data.servings', '8');
+
+    $this->assertDatabaseHas('recipes', [
+        'team_id' => $user->current_team_id,
+        'name' => 'Chocolate Cake',
+    ]);
+});
+
+test('store validates required fields', function () {
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('api.recipes.store'), [])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['name']);
+});
+
+test('show returns a recipe', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create();
+
+    $this->actingAs($user)
+        ->getJson(route('api.recipes.show', $recipe))
+        ->assertOk()
+        ->assertJsonPath('data.id', $recipe->id)
+        ->assertJsonPath('data.name', $recipe->name);
+});
+
+test('show returns 403 for another team recipe', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->create();
+
+    $this->actingAs($user)
+        ->getJson(route('api.recipes.show', $recipe))
+        ->assertForbidden();
+});
+
+test('update modifies a recipe', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create();
+
+    $this->actingAs($user)
+        ->patchJson(route('api.recipes.update', $recipe), [
+            'name' => 'Updated Name',
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.name', 'Updated Name');
+
+    $this->assertDatabaseHas('recipes', [
+        'id' => $recipe->id,
+        'name' => 'Updated Name',
+    ]);
+});
+
+test('update returns 403 for another team recipe', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->create();
+
+    $this->actingAs($user)
+        ->patchJson(route('api.recipes.update', $recipe), ['name' => 'Nope'])
+        ->assertForbidden();
+});
+
+test('destroy deletes a recipe', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create();
+
+    $this->actingAs($user)
+        ->deleteJson(route('api.recipes.destroy', $recipe))
+        ->assertNoContent();
+
+    $this->assertDatabaseMissing('recipes', ['id' => $recipe->id]);
+});
+
+test('destroy returns 403 for another team recipe', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->create();
+
+    $this->actingAs($user)
+        ->deleteJson(route('api.recipes.destroy', $recipe))
+        ->assertForbidden();
+});


### PR DESCRIPTION
This PR adds basic API endpoints for recipes.

`GET` /api/recipes - returns all the recipes for the user's current team
`POST` /api/recipes - creates a recipe
`GET` /api/recipes/{recipe} - returns a recipe
`PATCH` /api/recipes/{recipe} - updates a recipe
`DELETE` /api/recipes/{recipe} - deletes a recipe

Documentation for the API will be automatically generated at `/docs/api` and `/docs/api.json`

**Dependency**

* Added `dedoc/scramble` to `composer.json`, likely for API documentation generation.