### PR TITLE
Recipe photos

### DIFF
--- a/app/Actions/CreateRecipe.php
+++ b/app/Actions/CreateRecipe.php
@@ -6,6 +6,9 @@ namespace App\Actions;
 
 use App\Models\Recipe;
 use App\Models\Team;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
 
 class CreateRecipe
 {
@@ -14,6 +17,18 @@ class CreateRecipe
      */
     public function handle(Team $team, array $data): Recipe
     {
-        return $team->recipes()->create($data);
+        $photo = Arr::pull($data, 'photo');
+
+        $recipe = $team->recipes()->create($data);
+
+        if ($photo instanceof UploadedFile) {
+            $path = "teams/{$team->id}/recipes/{$recipe->slug}.{$photo->getClientOriginalExtension()}";
+
+            Storage::put($path, $photo);
+
+            $recipe->update(['photo_path' => $path]);
+        }
+
+        return $recipe;
     }
 }

--- a/app/Actions/CreateRecipe.php
+++ b/app/Actions/CreateRecipe.php
@@ -8,7 +8,6 @@ use App\Models\Recipe;
 use App\Models\Team;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Storage;
 
 class CreateRecipe
 {
@@ -22,9 +21,9 @@ class CreateRecipe
         $recipe = $team->recipes()->create($data);
 
         if ($photo instanceof UploadedFile) {
-            $path = "teams/{$team->id}/recipes/{$recipe->slug}.{$photo->getClientOriginalExtension()}";
+            $filename = "{$recipe->slug}.{$photo->getClientOriginalExtension()}";
 
-            Storage::put($path, $photo);
+            $path = $photo->storeAs("teams/{$team->id}/recipes", $filename);
 
             $recipe->update(['photo_path' => $path]);
         }

--- a/app/Actions/UpdateRecipe.php
+++ b/app/Actions/UpdateRecipe.php
@@ -31,9 +31,9 @@ class UpdateRecipe
                 Storage::delete($recipe->photo_path);
             }
 
-            $path = "teams/{$recipe->team_id}/recipes/{$recipe->slug}.{$photo->getClientOriginalExtension()}";
+            $filename = "{$recipe->slug}.{$photo->getClientOriginalExtension()}";
 
-            Storage::put($path, $photo);
+            $path = $photo->storeAs("teams/{$recipe->team_id}/recipes", $filename);
 
             $recipe->update(['photo_path' => $path]);
         }

--- a/app/Actions/UpdateRecipe.php
+++ b/app/Actions/UpdateRecipe.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Models\Recipe;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
 
 class UpdateRecipe
 {
@@ -13,7 +16,21 @@ class UpdateRecipe
      */
     public function handle(Recipe $recipe, array $data): Recipe
     {
+        $photo = Arr::pull($data, 'photo');
+
         $recipe->update($data);
+
+        if ($photo instanceof UploadedFile) {
+            if ($recipe->photo_path) {
+                Storage::delete($recipe->photo_path);
+            }
+
+            $path = "teams/{$recipe->team_id}/recipes/{$recipe->slug}.{$photo->getClientOriginalExtension()}";
+
+            Storage::put($path, $photo);
+
+            $recipe->update(['photo_path' => $path]);
+        }
 
         return $recipe;
     }

--- a/app/Actions/UpdateRecipe.php
+++ b/app/Actions/UpdateRecipe.php
@@ -14,13 +14,19 @@ class UpdateRecipe
     /**
      * @param  array<string, mixed>  $data
      */
-    public function handle(Recipe $recipe, array $data): Recipe
+    public function handle(Recipe $recipe, array $data, bool $removePhoto = false): Recipe
     {
         $photo = Arr::pull($data, 'photo');
 
         $recipe->update($data);
 
-        if ($photo instanceof UploadedFile) {
+        if ($removePhoto && ! $photo instanceof UploadedFile) {
+            if ($recipe->photo_path) {
+                Storage::delete($recipe->photo_path);
+            }
+
+            $recipe->update(['photo_path' => null]);
+        } elseif ($photo instanceof UploadedFile) {
             if ($recipe->photo_path) {
                 Storage::delete($recipe->photo_path);
             }

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -16,7 +16,7 @@ class RecipeResource extends JsonResource
     {
         return [
             ...Arr::except(parent::toArray($request), ['photo_path']),
-            'photo_url' => $this->photo_path ? Storage::url($this->photo_path) : null,
+            'photo_url' => $this->photo_path ? Storage::temporaryUrl($this->photo_path, now()->addMinutes(30)) : null,
         ];
     }
 }

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -6,12 +6,17 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
 
 class RecipeResource extends JsonResource
 {
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
-        return parent::toArray($request);
+        return [
+            ...Arr::except(parent::toArray($request), ['photo_path']),
+            'photo_url' => $this->photo_path ? Storage::url($this->photo_path) : null,
+        ];
     }
 }

--- a/app/Livewire/Forms/Recipes/RecipeForm.php
+++ b/app/Livewire/Forms/Recipes/RecipeForm.php
@@ -8,6 +8,7 @@ use App\Actions\CreateRecipe;
 use App\Actions\UpdateRecipe;
 use App\Models\Recipe;
 use Illuminate\Support\Facades\Auth;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\Form;
 
 class RecipeForm extends Form
@@ -38,6 +39,8 @@ class RecipeForm extends Form
     public ?string $notes = null;
 
     public ?string $nutrition = null;
+
+    public ?TemporaryUploadedFile $photo = null;
 
     public ?int $parent_id = null;
 
@@ -92,6 +95,7 @@ class RecipeForm extends Form
             'instructions' => ['nullable', 'string'],
             'notes' => ['nullable', 'string'],
             'nutrition' => ['nullable', 'string'],
+            'photo' => ['nullable', 'image', 'max:5120'],
             'parent_id' => ['nullable', 'integer', 'exists:recipes,id'],
         ];
     }

--- a/app/Livewire/Forms/Recipes/RecipeForm.php
+++ b/app/Livewire/Forms/Recipes/RecipeForm.php
@@ -66,7 +66,7 @@ class RecipeForm extends Form
             'notes' => $recipe->notes,
             'nutrition' => $recipe->nutrition,
             'parent_id' => $recipe->parent_id,
-            'existingPhotoUrl' => $recipe->photo_path ? Storage::url($recipe->photo_path) : null,
+            'existingPhotoUrl' => $recipe->photo_path ? Storage::temporaryUrl($recipe->photo_path, now()->addMinutes(30)) : null,
         ]);
     }
 

--- a/app/Livewire/Forms/Recipes/RecipeForm.php
+++ b/app/Livewire/Forms/Recipes/RecipeForm.php
@@ -45,6 +45,8 @@ class RecipeForm extends Form
 
     public ?string $existingPhotoUrl = null;
 
+    public bool $removePhoto = false;
+
     public ?int $parent_id = null;
 
     public function load(Recipe $recipe): void
@@ -72,10 +74,10 @@ class RecipeForm extends Form
     {
         $this->validate();
 
-        $data = $this->except(['editingRecipe', 'parent_id', 'existingPhotoUrl']);
+        $data = $this->except(['editingRecipe', 'parent_id', 'existingPhotoUrl', 'removePhoto']);
 
         if ($this->editingRecipe) {
-            (new UpdateRecipe)->handle($this->editingRecipe, $data);
+            (new UpdateRecipe)->handle($this->editingRecipe, $data, $this->removePhoto);
         } else {
             (new CreateRecipe)->handle(Auth::user()->currentTeam, $data);
         }

--- a/app/Livewire/Forms/Recipes/RecipeForm.php
+++ b/app/Livewire/Forms/Recipes/RecipeForm.php
@@ -8,6 +8,7 @@ use App\Actions\CreateRecipe;
 use App\Actions\UpdateRecipe;
 use App\Models\Recipe;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\Form;
 
@@ -42,6 +43,8 @@ class RecipeForm extends Form
 
     public ?TemporaryUploadedFile $photo = null;
 
+    public ?string $existingPhotoUrl = null;
+
     public ?int $parent_id = null;
 
     public function load(Recipe $recipe): void
@@ -61,6 +64,7 @@ class RecipeForm extends Form
             'notes' => $recipe->notes,
             'nutrition' => $recipe->nutrition,
             'parent_id' => $recipe->parent_id,
+            'existingPhotoUrl' => $recipe->photo_path ? Storage::url($recipe->photo_path) : null,
         ]);
     }
 
@@ -68,7 +72,7 @@ class RecipeForm extends Form
     {
         $this->validate();
 
-        $data = $this->except(['editingRecipe', 'parent_id']);
+        $data = $this->except(['editingRecipe', 'parent_id', 'existingPhotoUrl']);
 
         if ($this->editingRecipe) {
             (new UpdateRecipe)->handle($this->editingRecipe, $data);

--- a/app/Models/Recipe.php
+++ b/app/Models/Recipe.php
@@ -34,7 +34,7 @@ class Recipe extends Model
         'notes',
         'nutrition',
         'tags',
-        'photo',
+        'photo_path',
     ];
 
     protected static function booted(): void

--- a/database/migrations/2026_03_10_011618_add_photo_path_to_recipes_table.php
+++ b/database/migrations/2026_03_10_011618_add_photo_path_to_recipes_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->string('photo_path')->nullable()->after('nutrition');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->dropColumn('photo_path');
+        });
+    }
+};

--- a/resources/views/pages/recipes/detail.blade.php
+++ b/resources/views/pages/recipes/detail.blade.php
@@ -1,7 +1,7 @@
 <div class="grid gap-6 lg:grid-cols-3">
     <div class="space-y-6 lg:col-span-2">
         @if ($recipe->photo_path)
-            <img src="{{ Storage::url($recipe->photo_path) }}" alt="{{ $recipe->name }}" class="w-full rounded-lg object-cover max-h-96" />
+            <img src="{{ Storage::temporaryUrl($recipe->photo_path, now()->addMinutes(30)) }}" alt="{{ $recipe->name }}" class="w-full rounded-lg object-cover max-h-96" />
         @endif
         @if ($recipe->description)
             <flux:card>

--- a/resources/views/pages/recipes/detail.blade.php
+++ b/resources/views/pages/recipes/detail.blade.php
@@ -1,5 +1,8 @@
 <div class="grid gap-6 lg:grid-cols-3">
     <div class="space-y-6 lg:col-span-2">
+        @if ($recipe->photo_path)
+            <img src="{{ Storage::url($recipe->photo_path) }}" alt="{{ $recipe->name }}" class="w-full rounded-lg object-cover max-h-96" />
+        @endif
         @if ($recipe->description)
             <flux:card>
                 <flux:heading size="lg" class="mb-2">{{ __('Description') }}</flux:heading>

--- a/resources/views/pages/recipes/form.blade.php
+++ b/resources/views/pages/recipes/form.blade.php
@@ -24,9 +24,17 @@
 
         <div class="mt-4 flex flex-col gap-2">
         @if ($this->form->photo)
-            <flux:file-item :heading="$this->form->photo->getClientOriginalName()" :image="$this->form->photo->temporaryUrl()" :size="$this->form->photo->getSize()" />
+            <flux:file-item :heading="$this->form->photo->getClientOriginalName()" :image="$this->form->photo->temporaryUrl()" :size="$this->form->photo->getSize()">
+                <x-slot name="actions">
+                    <flux:button wire:click="removePhoto" variant="ghost" size="sm" icon="x-mark" />
+                </x-slot>
+            </flux:file-item>
         @elseif ($this->form->existingPhotoUrl)
-            <flux:file-item :heading="basename($this->form->editingRecipe->photo_path)" :image="$this->form->existingPhotoUrl" />
+            <flux:file-item :heading="basename($this->form->editingRecipe->photo_path)" :image="$this->form->existingPhotoUrl">
+                <x-slot name="actions">
+                    <flux:button wire:click="removePhoto" variant="ghost" size="sm" icon="x-mark" />
+                </x-slot>
+            </flux:file-item>
         @endif
         </div>
         <flux:error name="form.photo" />

--- a/resources/views/pages/recipes/form.blade.php
+++ b/resources/views/pages/recipes/form.blade.php
@@ -14,6 +14,24 @@
         </x-slot>
     </flux:input>
 
+    <flux:field>
+        <flux:label>{{ __('Photo') }}</flux:label>
+
+        <flux:file-upload wire:model="form.photo">
+
+            <flux:file-upload.dropzone :heading="__('Drop photo here or click to browse')" :text="__('JPG, PNG up to 5MB')" />
+        </flux:file-upload>
+
+        <div class="mt-4 flex flex-col gap-2">
+        @if ($this->form->photo)
+            <flux:file-item :heading="$this->form->photo->getClientOriginalName()" :image="$this->form->photo->temporaryUrl()" :size="$this->form->photo->getSize()" />
+        @elseif ($this->form->existingPhotoUrl)
+            <flux:file-item :heading="basename($this->form->editingRecipe->photo_path)" :image="$this->form->existingPhotoUrl" />
+        @endif
+        </div>
+        <flux:error name="form.photo" />
+    </flux:field>
+
     <flux:pillbox wire:model="form.tags" label="Tags" multiple placeholder="Choose tags...">
         <flux:pillbox.option>Breakfast</flux:pillbox.option>
         <flux:pillbox.option>Lunch</flux:pillbox.option>

--- a/resources/views/pages/recipes/form.blade.php
+++ b/resources/views/pages/recipes/form.blade.php
@@ -24,7 +24,7 @@
 
         <div class="mt-4 flex flex-col gap-2">
         @if ($this->form->photo)
-            <flux:file-item :heading="$this->form->photo->getClientOriginalName()" :image="$this->form->photo->temporaryUrl()" :size="$this->form->photo->getSize()">
+            <flux:file-item :heading="$this->form->photo->getClientOriginalName()" :image="$this->form->photo->isPreviewable() ? $this->form->photo->temporaryUrl() : null" :size="$this->form->photo->getSize()">
                 <x-slot name="actions">
                     <flux:button wire:click="removePhoto" variant="ghost" size="sm" icon="x-mark" />
                 </x-slot>

--- a/resources/views/pages/recipes/⚡create.blade.php
+++ b/resources/views/pages/recipes/⚡create.blade.php
@@ -29,8 +29,10 @@ new class extends Component {
 
     public function removePhoto(): void
     {
-        $this->form->photo->delete();
-        $this->form->photo = null;
+        if ($this->form->photo) {
+            $this->form->photo->delete();
+            $this->form->photo = null;
+        }
     }
 
     public function save(): void

--- a/resources/views/pages/recipes/⚡create.blade.php
+++ b/resources/views/pages/recipes/⚡create.blade.php
@@ -27,6 +27,12 @@ new class extends Component {
         }
     }
 
+    public function removePhoto(): void
+    {
+        $this->form->photo->delete();
+        $this->form->photo = null;
+    }
+
     public function save(): void
     {
         $this->form->save();

--- a/resources/views/pages/recipes/⚡create.blade.php
+++ b/resources/views/pages/recipes/⚡create.blade.php
@@ -4,8 +4,10 @@ use App\Actions\ImportRecipeFromUrl;
 use App\Livewire\Forms\Recipes\RecipeForm;
 use Flux\Flux;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 new class extends Component {
+    use WithFileUploads;
     public RecipeForm $form;
 
     public function import(): void

--- a/resources/views/pages/recipes/⚡create.test.php
+++ b/resources/views/pages/recipes/⚡create.test.php
@@ -2,7 +2,9 @@
 
 use App\Models\Recipe;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 test('can view page', function () {
@@ -106,4 +108,24 @@ test('import validates url is required', function () {
         ->set('form.source', 'not-a-url')
         ->call('import')
         ->assertHasErrors(['form.source']);
+});
+
+test('can upload a photo to a recipe', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.create')
+        ->set('form.name', 'Chocolate Cake')
+        ->set('form.photo', UploadedFile::fake()->image('download.png'))
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('recipes.index'));
+
+    expect(Recipe::firstWhere('name', 'Chocolate Cake'))->not->toBeNull()
+        ->team_id->toBe($user->current_team_id)
+        ->photo_path->toBe("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
+
+    Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
 });

--- a/resources/views/pages/recipes/⚡create.test.php
+++ b/resources/views/pages/recipes/⚡create.test.php
@@ -119,6 +119,7 @@ test('can upload a photo to a recipe', function () {
         ->test('pages::recipes.create')
         ->set('form.name', 'Chocolate Cake')
         ->set('form.photo', UploadedFile::fake()->image('download.png'))
+        ->assertSee('download.png')
         ->call('save')
         ->assertHasNoErrors()
         ->assertRedirect(route('recipes.index'));

--- a/resources/views/pages/recipes/⚡create.test.php
+++ b/resources/views/pages/recipes/⚡create.test.php
@@ -131,6 +131,32 @@ test('can upload a photo to a recipe', function () {
     Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
 });
 
+test('rejects non-image file uploads', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.create')
+        ->set('form.name', 'Chocolate Cake')
+        ->set('form.photo', UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'))
+        ->call('save')
+        ->assertHasErrors(['form.photo']);
+});
+
+test('rejects photo exceeding 5MB', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.create')
+        ->set('form.name', 'Chocolate Cake')
+        ->set('form.photo', UploadedFile::fake()->image('large.png')->size(6000))
+        ->call('save')
+        ->assertHasErrors(['form.photo']);
+});
+
 test('can remove a temporary uploaded photo', function () {
     Storage::fake();
 

--- a/resources/views/pages/recipes/⚡create.test.php
+++ b/resources/views/pages/recipes/⚡create.test.php
@@ -130,3 +130,18 @@ test('can upload a photo to a recipe', function () {
 
     Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
 });
+
+test('can remove a temporary uploaded photo', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.create')
+        ->set('form.name', 'Chocolate Cake')
+        ->set('form.photo', UploadedFile::fake()->image('download.png'))
+        ->assertSee('download.png')
+        ->call('removePhoto')
+        ->assertDontSee('download.png')
+        ->assertSet('form.photo', null);
+});

--- a/resources/views/pages/recipes/⚡edit.blade.php
+++ b/resources/views/pages/recipes/⚡edit.blade.php
@@ -4,8 +4,10 @@ use App\Actions\ImportRecipeFromUrl;
 use App\Livewire\Forms\Recipes\RecipeForm;
 use App\Models\Recipe;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 new class extends Component {
+    use WithFileUploads;
     public Recipe $recipe;
 
     public RecipeForm $form;

--- a/resources/views/pages/recipes/⚡edit.blade.php
+++ b/resources/views/pages/recipes/⚡edit.blade.php
@@ -34,6 +34,17 @@ new class extends Component {
         }
     }
 
+    public function removePhoto(): void
+    {
+        if ($this->form->photo) {
+            $this->form->photo->delete();
+            $this->form->photo = null;
+        } elseif ($this->form->existingPhotoUrl) {
+            $this->form->existingPhotoUrl = null;
+            $this->form->removePhoto = true;
+        }
+    }
+
     public function save(): void
     {
         $this->form->save();

--- a/resources/views/pages/recipes/⚡edit.test.php
+++ b/resources/views/pages/recipes/⚡edit.test.php
@@ -126,6 +126,35 @@ test('can remove a temporary uploaded photo', function () {
         ->assertDontSee('photo.png');
 });
 
+test('can remove existing photo then upload a new one', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'name' => 'Chocolate Cake',
+        'photo_path' => "teams/{$user->current_team_id}/recipes/chocolate-cake.png",
+    ]);
+
+    Storage::put($recipe->photo_path, 'old photo contents');
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.edit', ['recipe' => $recipe])
+        ->assertSee('chocolate-cake.png')
+        ->call('removePhoto')
+        ->assertDontSee('chocolate-cake.png')
+        ->set('form.photo', UploadedFile::fake()->image('new-photo.jpg'))
+        ->assertSee('new-photo.jpg')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('recipes.show', $recipe));
+
+    expect($recipe->fresh())
+        ->photo_path->toBe("teams/{$user->current_team_id}/recipes/chocolate-cake.jpg");
+
+    Storage::assertMissing("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
+    Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.jpg");
+});
+
 test('cannot edit a recipe from another team', function () {
     $user = User::factory()->withTeam()->create();
     $otherRecipe = Recipe::factory()->for(Team::factory())->create();

--- a/resources/views/pages/recipes/⚡edit.test.php
+++ b/resources/views/pages/recipes/⚡edit.test.php
@@ -70,7 +70,9 @@ test('can replace a photo on a recipe', function () {
 
     Livewire::actingAs($user)
         ->test('pages::recipes.edit', ['recipe' => $recipe])
+        ->assertSee('chocolate-cake.png')
         ->set('form.photo', UploadedFile::fake()->image('new-photo.jpg'))
+        ->assertSee('new-photo.jpg')
         ->call('save')
         ->assertHasNoErrors()
         ->assertRedirect(route('recipes.show', $recipe));

--- a/resources/views/pages/recipes/⚡edit.test.php
+++ b/resources/views/pages/recipes/⚡edit.test.php
@@ -3,6 +3,8 @@
 use App\Models\Recipe;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 test('can view edit page', function () {
@@ -34,6 +36,50 @@ test('can edit a recipe', function () {
         ->name->toBe('New Name')
         ->tags->toBe(['Dinner', 'Slow Cooker'])
         ->description->toBe('A delicious recipe');
+});
+
+test('can upload a photo to a recipe', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create(['name' => 'Chocolate Cake']);
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.edit', ['recipe' => $recipe])
+        ->set('form.photo', UploadedFile::fake()->image('photo.png'))
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('recipes.show', $recipe));
+
+    expect($recipe->fresh())
+        ->photo_path->toBe("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
+
+    Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
+});
+
+test('can replace a photo on a recipe', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'name' => 'Chocolate Cake',
+        'photo_path' => "teams/{$user->current_team_id}/recipes/chocolate-cake.png",
+    ]);
+
+    Storage::put($recipe->photo_path, 'old photo contents');
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.edit', ['recipe' => $recipe])
+        ->set('form.photo', UploadedFile::fake()->image('new-photo.jpg'))
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('recipes.show', $recipe));
+
+    expect($recipe->fresh())
+        ->photo_path->toBe("teams/{$user->current_team_id}/recipes/chocolate-cake.jpg");
+
+    Storage::assertMissing("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
+    Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.jpg");
 });
 
 test('cannot edit a recipe from another team', function () {

--- a/resources/views/pages/recipes/⚡edit.test.php
+++ b/resources/views/pages/recipes/⚡edit.test.php
@@ -84,6 +84,48 @@ test('can replace a photo on a recipe', function () {
     Storage::assertExists("teams/{$user->current_team_id}/recipes/chocolate-cake.jpg");
 });
 
+test('can remove an existing photo', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'name' => 'Chocolate Cake',
+        'photo_path' => "teams/{$user->current_team_id}/recipes/chocolate-cake.png",
+    ]);
+
+    Storage::put($recipe->photo_path, 'old photo contents');
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.edit', ['recipe' => $recipe])
+        ->assertSee('chocolate-cake.png')
+        ->call('removePhoto')
+        ->assertDontSee('chocolate-cake.png')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('recipes.show', $recipe));
+
+    expect($recipe->fresh())
+        ->photo_path->toBeNull();
+
+    Storage::assertMissing("teams/{$user->current_team_id}/recipes/chocolate-cake.png");
+});
+
+test('can remove a temporary uploaded photo', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'name' => 'Chocolate Cake',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test('pages::recipes.edit', ['recipe' => $recipe])
+        ->set('form.photo', UploadedFile::fake()->image('photo.png'))
+        ->assertSee('photo.png')
+        ->call('removePhoto')
+        ->assertDontSee('photo.png');
+});
+
 test('cannot edit a recipe from another team', function () {
     $user = User::factory()->withTeam()->create();
     $otherRecipe = Recipe::factory()->for(Team::factory())->create();

--- a/resources/views/pages/recipes/⚡show.test.php
+++ b/resources/views/pages/recipes/⚡show.test.php
@@ -117,7 +117,7 @@ test('displays photo when recipe has one', function () {
     $this->actingAs($user)
         ->get(route('recipes.show', $recipe))
         ->assertOk()
-        ->assertSee(Storage::url($recipe->photo_path));
+        ->assertSee('<img', false);
 });
 
 test('does not display photo when recipe has none', function () {

--- a/resources/views/pages/recipes/⚡show.test.php
+++ b/resources/views/pages/recipes/⚡show.test.php
@@ -2,6 +2,7 @@
 
 use App\Models\Recipe;
 use App\Models\User;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 test('can view a recipe', function () {
@@ -100,6 +101,36 @@ test('shows tags on recipe', function () {
         ->assertOk()
         ->assertSee('dinner')
         ->assertSee('italian');
+});
+
+test('displays photo when recipe has one', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'name' => 'Chocolate Cake',
+        'photo_path' => "teams/{$user->current_team_id}/recipes/chocolate-cake.png",
+    ]);
+
+    Storage::put($recipe->photo_path, 'photo contents');
+
+    $this->actingAs($user)
+        ->get(route('recipes.show', $recipe))
+        ->assertOk()
+        ->assertSee(Storage::url($recipe->photo_path));
+});
+
+test('does not display photo when recipe has none', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'name' => 'Chocolate Cake',
+        'photo_path' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('recipes.show', $recipe))
+        ->assertOk()
+        ->assertDontSee('<img');
 });
 
 test('non-owner cannot toggle sharing', function () {

--- a/tests/Feature/Api/RecipeControllerTest.php
+++ b/tests/Feature/Api/RecipeControllerTest.php
@@ -72,11 +72,12 @@ test('show returns photo_url when recipe has a photo', function () {
         'photo_path' => "teams/{$user->current_team_id}/recipes/cake.png",
     ]);
 
-    $this->actingAs($user)
+    $response = $this->actingAs($user)
         ->getJson(route('api.recipes.show', $recipe))
         ->assertOk()
-        ->assertJsonPath('data.photo_url', Storage::url($recipe->photo_path))
         ->assertJsonMissingPath('data.photo_path');
+
+    expect($response->json('data.photo_url'))->toBeString()->toContain('cake.png');
 });
 
 test('show returns null photo_url when recipe has no photo', function () {

--- a/tests/Feature/Api/RecipeControllerTest.php
+++ b/tests/Feature/Api/RecipeControllerTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Recipe;
 use App\Models\User;
+use Illuminate\Support\Facades\Storage;
 
 test('guests cannot access recipes', function () {
     $this->getJson(route('api.recipes.index'))->assertUnauthorized();
@@ -61,6 +62,31 @@ test('show returns a recipe', function () {
         ->assertOk()
         ->assertJsonPath('data.id', $recipe->id)
         ->assertJsonPath('data.name', $recipe->name);
+});
+
+test('show returns photo_url when recipe has a photo', function () {
+    Storage::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create([
+        'photo_path' => "teams/{$user->current_team_id}/recipes/cake.png",
+    ]);
+
+    $this->actingAs($user)
+        ->getJson(route('api.recipes.show', $recipe))
+        ->assertOk()
+        ->assertJsonPath('data.photo_url', Storage::url($recipe->photo_path))
+        ->assertJsonMissingPath('data.photo_path');
+});
+
+test('show returns null photo_url when recipe has no photo', function () {
+    $user = User::factory()->withTeam()->create();
+    $recipe = Recipe::factory()->for($user->currentTeam)->create(['photo_path' => null]);
+
+    $this->actingAs($user)
+        ->getJson(route('api.recipes.show', $recipe))
+        ->assertOk()
+        ->assertJsonPath('data.photo_url', null);
 });
 
 test('show returns 403 for another team recipe', function () {


### PR DESCRIPTION
This pull request adds support for uploading, storing, displaying, and removing recipe photos. It introduces a new `photo_path` attribute for recipes, updates forms and views to handle image uploads, and includes comprehensive tests for these features.