### PR TITLE
Add metadata to items

### DIFF
--- a/app/Livewire/Forms/Inventory/ItemForm.php
+++ b/app/Livewire/Forms/Inventory/ItemForm.php
@@ -76,7 +76,7 @@ class ItemForm extends Form
             'type' => ['required', Rule::enum(ItemType::class)],
             'parent_id' => ['nullable', 'integer', 'exists:items,id'],
             'metadata' => ['nullable', 'array'],
-            'metadata.*.key' => ['nullable', 'string', 'max:255'],
+            'metadata.*.key' => ['nullable', 'string', 'max:255', 'distinct'],
             'metadata.*.value' => ['nullable', 'string', 'max:255'],
         ];
     }

--- a/app/Livewire/Forms/Inventory/ItemForm.php
+++ b/app/Livewire/Forms/Inventory/ItemForm.php
@@ -20,19 +20,44 @@ class ItemForm extends Form
 
     public ?int $parent_id = null;
 
+    /** @var array<int, array{key: string, value: string}> */
+    public array $metadata = [];
+
     public function load(Item $item): void
     {
+        $metadata = collect($item->metadata ?? [])
+            ->map(fn (string $value, string $key) => ['key' => $key, 'value' => $value])
+            ->values()
+            ->all();
+
         $this->fill([
             'editingItem' => $item,
             'name' => $item->name,
             'type' => $item->type->value,
             'parent_id' => $item->parent_id,
+            'metadata' => $metadata,
         ]);
+    }
+
+    public function addMetadata(): void
+    {
+        $this->metadata[] = ['key' => '', 'value' => ''];
+    }
+
+    public function removeMetadata(int $index): void
+    {
+        unset($this->metadata[$index]);
+        $this->metadata = array_values($this->metadata);
     }
 
     public function save(): void
     {
         $data = $this->validate();
+
+        $data['metadata'] = collect($data['metadata'] ?? [])
+            ->filter(fn (array $pair) => $pair['key'] !== '')
+            ->mapWithKeys(fn (array $pair) => [$pair['key'] => $pair['value']])
+            ->all() ?: null;
 
         if ($this->editingItem) {
             $this->editingItem->update($data);
@@ -50,6 +75,9 @@ class ItemForm extends Form
             'name' => ['required', 'string', 'max:255'],
             'type' => ['required', Rule::enum(ItemType::class)],
             'parent_id' => ['nullable', 'integer', 'exists:items,id'],
+            'metadata' => ['nullable', 'array'],
+            'metadata.*.key' => ['nullable', 'string', 'max:255'],
+            'metadata.*.value' => ['nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Livewire/Forms/Inventory/ItemForm.php
+++ b/app/Livewire/Forms/Inventory/ItemForm.php
@@ -77,7 +77,7 @@ class ItemForm extends Form
             'parent_id' => ['nullable', 'integer', 'exists:items,id'],
             'metadata' => ['nullable', 'array'],
             'metadata.*.key' => ['nullable', 'string', 'max:255', 'distinct'],
-            'metadata.*.value' => ['nullable', 'string', 'max:255'],
+            'metadata.*.value' => ['required_with:metadata.*.key', 'nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -22,6 +22,7 @@ class Item extends Model
         'parent_id',
         'type',
         'name',
+        'metadata',
     ];
 
     /** @return BelongsTo<Team, $this> */
@@ -47,6 +48,7 @@ class Item extends Model
     {
         return [
             'type' => ItemType::class,
+            'metadata' => 'array',
         ];
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.371.5",
+            "version": "3.373.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "d40b962154a146901f71561519f9d9c5a3863a6e"
+                "reference": "483fba51c28b3a0c0647bf5100e0edca82090b18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d40b962154a146901f71561519f9d9c5a3863a6e",
-                "reference": "d40b962154a146901f71561519f9d9c5a3863a6e",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/483fba51c28b3a0c0647bf5100e0edca82090b18",
+                "reference": "483fba51c28b3a0c0647bf5100e0edca82090b18",
                 "shasum": ""
             },
             "require": {
@@ -92,12 +92,12 @@
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.371.5"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.373.2"
             },
-            "time": "2026-03-04T19:06:59+00:00"
+            "time": "2026-03-13T18:08:30+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -1188,16 +1188,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -1213,6 +1213,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -1284,7 +1285,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -1300,7 +1301,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -1390,16 +1391,16 @@
         },
         {
             "name": "laravel/fortify",
-            "version": "v1.35.0",
+            "version": "v1.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/fortify.git",
-                "reference": "24c5bb81ea4787e0865c4a62f054ed7d1cb7a093"
+                "reference": "cad8bfeb63f6818f173d40090725c565c92651d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/fortify/zipball/24c5bb81ea4787e0865c4a62f054ed7d1cb7a093",
-                "reference": "24c5bb81ea4787e0865c4a62f054ed7d1cb7a093",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/cad8bfeb63f6818f173d40090725c565c92651d4",
+                "reference": "cad8bfeb63f6818f173d40090725c565c92651d4",
                 "shasum": ""
             },
             "require": {
@@ -1449,20 +1450,20 @@
                 "issues": "https://github.com/laravel/fortify/issues",
                 "source": "https://github.com/laravel/fortify"
             },
-            "time": "2026-02-24T14:00:44+00:00"
+            "time": "2026-03-10T19:59:49+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v12.53.0",
+            "version": "v12.54.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "f57f035c0d34503d9ff30be76159bb35a003cd1f"
+                "reference": "325497463e7599cd14224c422c6e5dd2fe832868"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/f57f035c0d34503d9ff30be76159bb35a003cd1f",
-                "reference": "f57f035c0d34503d9ff30be76159bb35a003cd1f",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/325497463e7599cd14224c422c6e5dd2fe832868",
+                "reference": "325497463e7599cd14224c422c6e5dd2fe832868",
                 "shasum": ""
             },
             "require": {
@@ -1483,7 +1484,7 @@
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.7",
+                "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
@@ -1671,20 +1672,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-24T14:35:15+00:00"
+            "time": "2026-03-10T20:25:56+00:00"
         },
         {
             "name": "laravel/nightwatch",
-            "version": "v1.24.0",
+            "version": "v1.24.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/nightwatch.git",
-                "reference": "444f638e548bd9de999ae671aec8cffc571713cc"
+                "reference": "627e58096f6b4b88e658b7a9cff595089036ae84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/nightwatch/zipball/444f638e548bd9de999ae671aec8cffc571713cc",
-                "reference": "444f638e548bd9de999ae671aec8cffc571713cc",
+                "url": "https://api.github.com/repos/laravel/nightwatch/zipball/627e58096f6b4b88e658b7a9cff595089036ae84",
+                "reference": "627e58096f6b4b88e658b7a9cff595089036ae84",
                 "shasum": ""
             },
             "require": {
@@ -1765,20 +1766,20 @@
                 "issues": "https://github.com/laravel/nightwatch/issues",
                 "source": "https://github.com/laravel/nightwatch"
             },
-            "time": "2026-02-27T18:23:32+00:00"
+            "time": "2026-03-12T04:01:23+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.13",
+            "version": "v0.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "ed8c466571b37e977532fb2fd3c272c784d7050d"
+                "reference": "9f0e371244eedfe2ebeaa72c79c54bb5df6e0176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/ed8c466571b37e977532fb2fd3c272c784d7050d",
-                "reference": "ed8c466571b37e977532fb2fd3c272c784d7050d",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/9f0e371244eedfe2ebeaa72c79c54bb5df6e0176",
+                "reference": "9f0e371244eedfe2ebeaa72c79c54bb5df6e0176",
                 "shasum": ""
             },
             "require": {
@@ -1822,9 +1823,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.13"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.14"
             },
-            "time": "2026-02-06T12:17:10+00:00"
+            "time": "2026-03-01T09:02:38+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -2018,16 +2019,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "84b1ca48347efdbe775426f108622a42735a6579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/84b1ca48347efdbe775426f108622a42735a6579",
+                "reference": "84b1ca48347efdbe775426f108622a42735a6579",
                 "shasum": ""
             },
             "require": {
@@ -2052,9 +2053,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -2121,7 +2122,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-05T21:37:03+00:00"
         },
         {
             "name": "league/config",
@@ -3076,16 +3077,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.1",
+            "version": "3.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "f438fcc98f92babee98381d399c65336f3a3827f"
+                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/f438fcc98f92babee98381d399c65336f3a3827f",
-                "reference": "f438fcc98f92babee98381d399c65336f3a3827f",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6a7e652845bb018c668220c2a545aded8594fbbf",
+                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf",
                 "shasum": ""
             },
             "require": {
@@ -3177,7 +3178,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:26:29+00:00"
+            "time": "2026-03-11T17:23:39+00:00"
         },
         {
             "name": "nette/schema",
@@ -4217,16 +4218,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.20",
+            "version": "v0.12.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "19678eb6b952a03b8a1d96ecee9edba518bb0373"
+                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/19678eb6b952a03b8a1d96ecee9edba518bb0373",
-                "reference": "19678eb6b952a03b8a1d96ecee9edba518bb0373",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
+                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
                 "shasum": ""
             },
             "require": {
@@ -4290,9 +4291,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.20"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.21"
             },
-            "time": "2026-02-11T15:05:28+00:00"
+            "time": "2026-03-06T21:21:28+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4632,16 +4633,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d643a93b47398599124022eb24d97c153c12f27"
+                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d643a93b47398599124022eb24d97c153c12f27",
-                "reference": "6d643a93b47398599124022eb24d97c153c12f27",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
                 "shasum": ""
             },
             "require": {
@@ -4706,7 +4707,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.6"
+                "source": "https://github.com/symfony/console/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4726,7 +4727,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T17:02:47+00:00"
+            "time": "2026-03-06T14:06:20+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -5247,16 +5248,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065"
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd97d5e926e988a363cef56fbbf88c5c528e9065",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
                 "shasum": ""
             },
             "require": {
@@ -5305,7 +5306,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -5325,20 +5326,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-21T16:25:55+00:00"
+            "time": "2026-03-06T13:15:18+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83"
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
-                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3b3fcf386c809be990c922e10e4c620d6367cab1",
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1",
                 "shasum": ""
             },
             "require": {
@@ -5424,7 +5425,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -5444,7 +5445,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-26T08:30:57+00:00"
+            "time": "2026-03-06T16:33:18+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -5532,16 +5533,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "9fc881d95feae4c6c48678cb6372bd8a7ba04f5f"
+                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/9fc881d95feae4c6c48678cb6372bd8a7ba04f5f",
-                "reference": "9fc881d95feae4c6c48678cb6372bd8a7ba04f5f",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
                 "shasum": ""
             },
             "require": {
@@ -5597,7 +5598,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.6"
+                "source": "https://github.com/symfony/mime/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -5617,7 +5618,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-05T15:57:06+00:00"
+            "time": "2026-03-05T15:24:09+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -8739,16 +8740,16 @@
         },
         {
             "name": "driftingly/rector-laravel",
-            "version": "2.1.9",
+            "version": "2.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/driftingly/rector-laravel.git",
-                "reference": "aee9d4a1d489e7ec484fc79f33137f8ee051b3f7"
+                "reference": "2a2175eefabca6d15c247d55de17c75dc2f787a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/aee9d4a1d489e7ec484fc79f33137f8ee051b3f7",
-                "reference": "aee9d4a1d489e7ec484fc79f33137f8ee051b3f7",
+                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/2a2175eefabca6d15c247d55de17c75dc2f787a9",
+                "reference": "2a2175eefabca6d15c247d55de17c75dc2f787a9",
                 "shasum": ""
             },
             "require": {
@@ -8769,9 +8770,9 @@
             "description": "Rector upgrades rules for Laravel Framework",
             "support": {
                 "issues": "https://github.com/driftingly/rector-laravel/issues",
-                "source": "https://github.com/driftingly/rector-laravel/tree/2.1.9"
+                "source": "https://github.com/driftingly/rector-laravel/tree/2.1.12"
             },
-            "time": "2025-12-25T23:31:36+00:00"
+            "time": "2026-03-06T19:59:21+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -9139,24 +9140,24 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.2.2",
+            "version": "v2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "2b0366559e9ff591c65ea0321dfb91fd950c2cbd"
+                "reference": "ba0a9e6497398b6ce8243f5517b67d6761509150"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/2b0366559e9ff591c65ea0321dfb91fd950c2cbd",
-                "reference": "2b0366559e9ff591c65ea0321dfb91fd950c2cbd",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/ba0a9e6497398b6ce8243f5517b67d6761509150",
+                "reference": "ba0a9e6497398b6ce8243f5517b67d6761509150",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^7.9",
-                "illuminate/console": "^11.45.3|^12.41.1",
-                "illuminate/contracts": "^11.45.3|^12.41.1",
-                "illuminate/routing": "^11.45.3|^12.41.1",
-                "illuminate/support": "^11.45.3|^12.41.1",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
                 "laravel/mcp": "^0.5.1|^0.6.0",
                 "laravel/prompts": "^0.3.10",
                 "laravel/roster": "^0.5.0",
@@ -9165,7 +9166,7 @@
             "require-dev": {
                 "laravel/pint": "^1.27.0",
                 "mockery/mockery": "^1.6.12",
-                "orchestra/testbench": "^9.15.0|^10.6",
+                "orchestra/testbench": "^9.15.0|^10.6|^11.0",
                 "pestphp/pest": "^2.36.0|^3.8.4|^4.1.5",
                 "phpstan/phpstan": "^2.1.27",
                 "rector/rector": "^2.1"
@@ -9201,20 +9202,20 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-03-03T14:36:03+00:00"
+            "time": "2026-03-12T09:06:47+00:00"
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.6.0",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "28860a10ca0cc5433e25d897ba7af844e6c7b6a2"
+                "reference": "f696e44735b95ff275392eab8ce5a3b4b42a2223"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/28860a10ca0cc5433e25d897ba7af844e6c7b6a2",
-                "reference": "28860a10ca0cc5433e25d897ba7af844e6c7b6a2",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/f696e44735b95ff275392eab8ce5a3b4b42a2223",
+                "reference": "f696e44735b95ff275392eab8ce5a3b4b42a2223",
                 "shasum": ""
             },
             "require": {
@@ -9274,7 +9275,7 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2026-02-24T08:43:06+00:00"
+            "time": "2026-03-10T20:00:23+00:00"
         },
         {
             "name": "laravel/pail",
@@ -9358,16 +9359,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.27.1",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5"
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/54cca2de13790570c7b6f0f94f37896bee4abcb5",
-                "reference": "54cca2de13790570c7b6f0f94f37896bee4abcb5",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/bdec963f53172c5e36330f3a400604c69bf02d39",
+                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39",
                 "shasum": ""
             },
             "require": {
@@ -9378,13 +9379,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.93.1",
-                "illuminate/view": "^12.51.0",
-                "larastan/larastan": "^3.9.2",
+                "friendsofphp/php-cs-fixer": "^3.94.2",
+                "illuminate/view": "^12.54.1",
+                "larastan/larastan": "^3.9.3",
                 "laravel-zero/framework": "^12.0.5",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^2.3.3",
-                "pestphp/pest": "^3.8.5"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6",
+                "shipfastlabs/agent-detector": "^1.1.0"
             },
             "bin": [
                 "builds/pint"
@@ -9421,20 +9423,20 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-02-10T20:00:20+00:00"
+            "time": "2026-03-12T15:51:39+00:00"
         },
         {
             "name": "laravel/roster",
-            "version": "v0.5.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/roster.git",
-                "reference": "56904a78f4d7360c1c490ced7deeebf9aecb8c0e"
+                "reference": "5089de7615f72f78e831590ff9d0435fed0102bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/roster/zipball/56904a78f4d7360c1c490ced7deeebf9aecb8c0e",
-                "reference": "56904a78f4d7360c1c490ced7deeebf9aecb8c0e",
+                "url": "https://api.github.com/repos/laravel/roster/zipball/5089de7615f72f78e831590ff9d0435fed0102bb",
+                "reference": "5089de7615f72f78e831590ff9d0435fed0102bb",
                 "shasum": ""
             },
             "require": {
@@ -9482,7 +9484,7 @@
                 "issues": "https://github.com/laravel/roster/issues",
                 "source": "https://github.com/laravel/roster"
             },
-            "time": "2026-02-17T17:33:35+00:00"
+            "time": "2026-03-05T07:58:43+00:00"
         },
         {
             "name": "laravel/sail",
@@ -9812,21 +9814,21 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.4.1",
+            "version": "v4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "f96a1b27864b585b0b29b0ee7331176726f7e54a"
+                "reference": "5d42e8fe3ae1d9fdf7c9f73ee88138fd30265701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/f96a1b27864b585b0b29b0ee7331176726f7e54a",
-                "reference": "f96a1b27864b585b0b29b0ee7331176726f7e54a",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/5d42e8fe3ae1d9fdf7c9f73ee88138fd30265701",
+                "reference": "5d42e8fe3ae1d9fdf7c9f73ee88138fd30265701",
                 "shasum": ""
             },
             "require": {
                 "brianium/paratest": "^7.19.0",
-                "nunomaduro/collision": "^8.9.0",
+                "nunomaduro/collision": "^8.9.1",
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^4.0.0",
                 "pestphp/pest-plugin-arch": "^4.0.0",
@@ -9846,7 +9848,7 @@
                 "pestphp/pest-dev-tools": "^4.1.0",
                 "pestphp/pest-plugin-browser": "^4.3.0",
                 "pestphp/pest-plugin-type-coverage": "^4.0.3",
-                "psy/psysh": "^0.12.20"
+                "psy/psysh": "^0.12.21"
             },
             "bin": [
                 "bin/pest"
@@ -9912,7 +9914,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.4.1"
+                "source": "https://github.com/pestphp/pest/tree/v4.4.2"
             },
             "funding": [
                 {
@@ -9924,7 +9926,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-17T15:27:18+00:00"
+            "time": "2026-03-10T21:09:12+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -12421,28 +12423,28 @@
         },
         {
             "name": "tightenco/duster",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tighten/duster.git",
-                "reference": "0260abaaecabd9655a0836e4038238e6585a8b45"
+                "reference": "911669fc874a1af4de87cf021cdb58a97584ec52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tighten/duster/zipball/0260abaaecabd9655a0836e4038238e6585a8b45",
-                "reference": "0260abaaecabd9655a0836e4038238e6585a8b45",
+                "url": "https://api.github.com/repos/tighten/duster/zipball/911669fc874a1af4de87cf021cdb58a97584ec52",
+                "reference": "911669fc874a1af4de87cf021cdb58a97584ec52",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.73",
-                "laravel-zero/framework": "^11.36",
-                "laravel/pint": "^1.21",
-                "nunomaduro/termwind": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.94",
+                "laravel-zero/framework": "^12.0",
+                "laravel/pint": "^1.27",
+                "nunomaduro/termwind": "^2.4",
                 "spatie/invade": "^1.1",
-                "squizlabs/php_codesniffer": "^3.12",
+                "squizlabs/php_codesniffer": "^4.0",
                 "tightenco/tlint": "^9.5"
             },
             "bin": [
@@ -12485,7 +12487,7 @@
                 "issues": "https://github.com/tighten/duster/issues",
                 "source": "https://github.com/tighten/duster"
             },
-            "time": "2025-11-07T15:00:12+00:00"
+            "time": "2026-03-06T22:05:01+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/database/migrations/2026_03_14_043541_add_metadata_to_items_table.php
+++ b/database/migrations/2026_03_14_043541_add_metadata_to_items_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->json('metadata')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('items', function (Blueprint $table) {
+            $table->dropColumn('metadata');
+        });
+    }
+};

--- a/resources/views/pages/inventory/⚡index.blade.php
+++ b/resources/views/pages/inventory/⚡index.blade.php
@@ -100,6 +100,16 @@ new #[Title('Inventory')] class extends Component {
         $this->modal('item-form')->show();
     }
 
+    public function addMetadata(): void
+    {
+        $this->form->addMetadata();
+    }
+
+    public function removeMetadata(int $index): void
+    {
+        $this->form->removeMetadata($index);
+    }
+
     public function save(): void
     {
         $this->form->save();
@@ -198,6 +208,22 @@ new #[Title('Inventory')] class extends Component {
                     <flux:select.option :value="$parentItem->id">{{ $parentItem->name }}</flux:select.option>
                 @endforeach
             </flux:select>
+
+            <div>
+                <flux:label class="mb-2">{{ __('Metadata') }}</flux:label>
+
+                <div class="space-y-2">
+                    @foreach ($form->metadata as $index => $pair)
+                        <div class="flex items-start gap-2">
+                            <flux:input wire:model="form.metadata.{{ $index }}.key" placeholder="{{ __('Key') }}" size="sm" />
+                            <flux:input wire:model="form.metadata.{{ $index }}.value" placeholder="{{ __('Value') }}" size="sm" />
+                            <flux:button variant="ghost" size="sm" icon="x-mark" wire:click="removeMetadata({{ $index }})" />
+                        </div>
+                    @endforeach
+                </div>
+
+                <flux:button variant="ghost" size="sm" icon="plus" wire:click="addMetadata" class="mt-2">{{ __('Add field') }}</flux:button>
+            </div>
 
             <div class="flex">
                 <flux:spacer />

--- a/resources/views/pages/inventory/⚡index.test.php
+++ b/resources/views/pages/inventory/⚡index.test.php
@@ -59,202 +59,303 @@ test('can sort items', function () {
         ->assertSeeInOrder(['Bravo', 'Alpha']);
 });
 
-test('can create an item without a parent', function () {
-    $user = User::factory()->withTeam()->create();
+describe('can navigate up and down', function () {
+    test('can navigate down into a child item', function () {
+        $user = User::factory()->withTeam()->create();
+        $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
+        Item::factory()->for($user->currentTeam)->bin()->childOf($parent)->create(['name' => 'Closet']);
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->set('form.name', 'Guitar')
-        ->set('form.type', ItemType::Item)
-        ->call('save')
-        ->assertHasNoErrors();
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->assertSeeHtml('<span>Bedroom</span>')
+            ->assertDontSeeHtml('<span>Closet</span>')
+            ->call('navigateDown', $parent->id)
+            ->assertSeeHtml('<span>Closet</span>')
+            ->assertSet('parentId', $parent->id);
+    });
 
-    expect(Item::firstWhere('name', 'Guitar'))->not->toBeNull()
-        ->team_id->toBe($user->current_team_id)
-        ->parent_id->toBeNull();
+    test('can navigate up from a child item', function () {
+        $user = User::factory()->withTeam()->create();
+        $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
+        Item::factory()->for($user->currentTeam)->bin()->childOf($parent)->create(['name' => 'Closet']);
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('navigateDown', $parent->id)
+            ->assertSee('Closet')
+            ->call('navigateUp')
+            ->assertSee('Bedroom');
+    });
+
+    test('breadcrumbs show full ancestor path', function () {
+        $user = User::factory()->withTeam()->create();
+        $bedroom = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
+        $closet = Item::factory()->for($user->currentTeam)->bin()->childOf($bedroom)->create(['name' => 'Right Closet']);
+        $tote = Item::factory()->for($user->currentTeam)->bin()->childOf($closet)->create(['name' => 'Game Tote']);
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('navigateDown', $bedroom->id)
+            ->call('navigateDown', $closet->id)
+            ->call('navigateDown', $tote->id)
+            ->assertSeeInOrder(['All', 'Bedroom', 'Right Closet', 'Game Tote']);
+    });
+
+    test('breadcrumbs are empty at root level', function () {
+        $user = User::factory()->withTeam()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->assertSee('All')
+            ->assertSet('parentId', null);
+    });
+
+    test('clicking a breadcrumb navigates to that level', function () {
+        $user = User::factory()->withTeam()->create();
+        $bedroom = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
+        $closet = Item::factory()->for($user->currentTeam)->bin()->childOf($bedroom)->create(['name' => 'Right Closet']);
+        Item::factory()->for($user->currentTeam)->bin()->childOf($closet)->create(['name' => 'Game Tote']);
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('navigateDown', $bedroom->id)
+            ->call('navigateDown', $closet->id)
+            ->assertSeeHtml('<span>Game Tote</span>')
+            ->call('navigateDown', $bedroom->id)
+            ->assertSet('parentId', $bedroom->id)
+            ->assertSeeHtml('<span>Right Closet</span>')
+            ->assertDontSeeHtml('<span>Game Tote</span>');
+    });
 });
 
-test('can create an item with a parent', function () {
-    $user = User::factory()->withTeam()->create();
-    $location = Item::factory()->for($user->currentTeam)->create(['name' => 'Bedroom']);
+describe('can create and edit', function () {
+    test('create pre-fills parent_id with current parentId', function () {
+        $user = User::factory()->withTeam()->create();
+        $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->set('form.name', 'Guitar')
-        ->set('form.type', 'item')
-        ->set('form.parent_id', $location->id)
-        ->call('save')
-        ->assertHasNoErrors()
-        ->assertSet('form.name', '')
-        ->set('form.type', null)
-        ->assertSet('form.parent_id', null);
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('navigateDown', $parent->id)
+            ->call('create')
+            ->assertSet('form.parent_id', $parent->id);
+    });
 
-    expect(Item::firstWhere('name', 'Guitar'))
-        ->team_id->toBe($user->current_team_id)
-        ->parent_id->toBe($location->id);
+    test('create does not pre-fill parent_id at root level', function () {
+        $user = User::factory()->withTeam()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('create')
+            ->assertSet('form.parent_id', null);
+    });
+
+    test('create resets form before pre-filling parent_id', function () {
+        $user = User::factory()->withTeam()->create();
+        $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
+        $item = Item::factory()->for($user->currentTeam)->childOf($parent)->create(['name' => 'Guitar']);
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('navigateDown', $parent->id)
+            ->call('edit', $item->id)
+            ->assertSet('form.name', 'Guitar')
+            ->call('create')
+            ->assertSet('form.name', '')
+            ->assertSet('form.parent_id', $parent->id);
+    });
+
+    test('can create an item without a parent', function () {
+        $user = User::factory()->withTeam()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->set('form.name', 'Guitar')
+            ->set('form.type', ItemType::Item)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect(Item::firstWhere('name', 'Guitar'))->not->toBeNull()
+            ->team_id->toBe($user->current_team_id)
+            ->parent_id->toBeNull();
+    });
+
+    test('can create an item with a parent', function () {
+        $user = User::factory()->withTeam()->create();
+        $location = Item::factory()->for($user->currentTeam)->create(['name' => 'Bedroom']);
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->set('form.name', 'Guitar')
+            ->set('form.type', 'item')
+            ->set('form.parent_id', $location->id)
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertSet('form.name', '')
+            ->set('form.type', null)
+            ->assertSet('form.parent_id', null);
+
+        expect(Item::firstWhere('name', 'Guitar'))
+            ->team_id->toBe($user->current_team_id)
+            ->parent_id->toBe($location->id);
+    });
+
+    test('can edit an item', function () {
+        $user = User::factory()->withTeam()->create();
+        $bin = Item::factory()->for($user->currentTeam)->create(['name' => 'Soft Shell Case', 'type' => ItemType::Bin]);
+        $item = Item::factory()->for($user->currentTeam)->create(['name' => 'Guitar']);
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('edit', $item->id)
+            ->assertSet('form.name', 'Guitar')
+            ->assertSet('form.parent_id', null)
+            ->set('form.name', 'Yamaha Guitar')
+            ->set('form.parent_id', $bin->id)
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertSet('form.name', '')
+            ->assertSet('form.parent_id', null);
+
+        expect($item->fresh())
+            ->name->toBe('Yamaha Guitar')
+            ->parent_id->toBe($bin->id);
+    });
+
+    test('cannot edit an item from another team', function () {
+        $user = User::factory()->withTeam()->create();
+        $otherItem = Item::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('edit', $otherItem->id);
+    })->throws(ModelNotFoundException::class);
 });
 
-test('can edit an item', function () {
-    $user = User::factory()->withTeam()->create();
-    $bin = Item::factory()->for($user->currentTeam)->create(['name' => 'Soft Shell Case', 'type' => ItemType::Bin]);
-    $item = Item::factory()->for($user->currentTeam)->create(['name' => 'Guitar']);
+describe('can delete', function () {
+    test('can delete an item', function () {
+        $user = User::factory()->withTeam()->create();
+        $item = Item::factory()->for($user->currentTeam)->create();
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('edit', $item->id)
-        ->assertSet('form.name', 'Guitar')
-        ->assertSet('form.parent_id', null)
-        ->set('form.name', 'Yamaha Guitar')
-        ->set('form.parent_id', $bin->id)
-        ->call('save')
-        ->assertHasNoErrors()
-        ->assertSet('form.name', '')
-        ->assertSet('form.parent_id', null);
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('delete', $item->id);
 
-    expect($item->fresh())
-        ->name->toBe('Yamaha Guitar')
-        ->parent_id->toBe($bin->id);
+        expect($item->fresh())->toBeNull();
+    });
+
+    test('cannot delete an item from another team', function () {
+        $user = User::factory()->withTeam()->create();
+        $item = Item::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('delete', $item->id);
+    })->throws(ModelNotFoundException::class);
+
+    test('deleting a parent nullifies children parent_id', function () {
+        $user = User::factory()->withTeam()->create();
+        $parent = Item::factory()->for($user->currentTeam)->location()->create();
+        $child = Item::factory()->for($user->currentTeam)->childOf($parent)->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('delete', $parent->id);
+
+        expect($child->fresh()->parent_id)->toBeNull();
+    });
 });
 
-test('can delete an item', function () {
-    $user = User::factory()->withTeam()->create();
-    $item = Item::factory()->for($user->currentTeam)->create();
+describe('can add item metadata', function () {
+    test('can create an item with metadata', function () {
+        $user = User::factory()->withTeam()->create();
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('delete', $item->id);
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('create')
+            ->set('form.name', 'Test Item')
+            ->set('form.type', ItemType::Item->value)
+            ->set('form.metadata', [
+                ['key' => 'url', 'value' => 'https://amazon.com'],
+                ['key' => 'price', 'value' => '$20'],
+            ])
+            ->call('save');
 
-    expect($item->fresh())->toBeNull();
-});
+        $item = Item::where('name', 'Test Item')->first();
 
-test('cannot edit an item from another team', function () {
-    $user = User::factory()->withTeam()->create();
-    $otherItem = Item::factory()->create();
+        expect($item)
+            ->not->toBeNull()
+            ->metadata->toBe([
+                'url' => 'https://amazon.com',
+                'price' => '$20',
+            ]);
+    });
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('edit', $otherItem->id);
-})->throws(ModelNotFoundException::class);
+    test('can update an item with metadata', function () {
+        $user = User::factory()->withTeam()->create();
+        $item = Item::factory()->for($user->currentTeam)->create([
+            'metadata' => ['color' => 'red'],
+        ]);
 
-test('cannot delete an item from another team', function () {
-    $user = User::factory()->withTeam()->create();
-    $item = Item::factory()->create();
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('edit', $item->id)
+            ->set('form.metadata', [
+                ['key' => 'color', 'value' => 'blue'],
+                ['key' => 'size', 'value' => 'large'],
+            ])
+            ->call('save');
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('delete', $item->id);
-})->throws(ModelNotFoundException::class);
+        expect($item->fresh()->metadata)->toBe([
+            'color' => 'blue',
+            'size' => 'large',
+        ]);
+    });
 
-test('can navigate down into a child item', function () {
-    $user = User::factory()->withTeam()->create();
-    $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
-    Item::factory()->for($user->currentTeam)->bin()->childOf($parent)->create(['name' => 'Closet']);
+    test('empty metadata keys are filtered out', function () {
+        $user = User::factory()->withTeam()->create();
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->assertSeeHtml('<span>Bedroom</span>')
-        ->assertDontSeeHtml('<span>Closet</span>')
-        ->call('navigateDown', $parent->id)
-        ->assertSeeHtml('<span>Closet</span>')
-        ->assertSet('parentId', $parent->id);
-});
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('create')
+            ->set('form.name', 'Filtered Item')
+            ->set('form.type', ItemType::Item->value)
+            ->set('form.metadata', [
+                ['key' => '', 'value' => 'orphan'],
+                ['key' => 'valid', 'value' => 'kept'],
+            ])
+            ->call('save');
 
-test('can navigate up from a child item', function () {
-    $user = User::factory()->withTeam()->create();
-    $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
-    Item::factory()->for($user->currentTeam)->bin()->childOf($parent)->create(['name' => 'Closet']);
+        $item = Item::where('name', 'Filtered Item')->first();
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('navigateDown', $parent->id)
-        ->assertSee('Closet')
-        ->call('navigateUp')
-        ->assertSee('Bedroom');
-});
+        expect($item->metadata)->toBe(['valid' => 'kept']);
+    });
 
-test('breadcrumbs show full ancestor path', function () {
-    $user = User::factory()->withTeam()->create();
-    $bedroom = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
-    $closet = Item::factory()->for($user->currentTeam)->bin()->childOf($bedroom)->create(['name' => 'Right Closet']);
-    $tote = Item::factory()->for($user->currentTeam)->bin()->childOf($closet)->create(['name' => 'Game Tote']);
+    test('item with no metadata stores null', function () {
+        $user = User::factory()->withTeam()->create();
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('navigateDown', $bedroom->id)
-        ->call('navigateDown', $closet->id)
-        ->call('navigateDown', $tote->id)
-        ->assertSeeInOrder(['All', 'Bedroom', 'Right Closet', 'Game Tote']);
-});
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('create')
+            ->set('form.name', 'No Meta Item')
+            ->set('form.type', ItemType::Item->value)
+            ->call('save');
 
-test('breadcrumbs are empty at root level', function () {
-    $user = User::factory()->withTeam()->create();
+        $item = Item::where('name', 'No Meta Item')->first();
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->assertSee('All')
-        ->assertSet('parentId', null);
-});
+        expect($item->metadata)->toBeNull();
+    });
 
-test('clicking a breadcrumb navigates to that level', function () {
-    $user = User::factory()->withTeam()->create();
-    $bedroom = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
-    $closet = Item::factory()->for($user->currentTeam)->bin()->childOf($bedroom)->create(['name' => 'Right Closet']);
-    Item::factory()->for($user->currentTeam)->bin()->childOf($closet)->create(['name' => 'Game Tote']);
+    test('editing an item loads existing metadata', function () {
+        $user = User::factory()->withTeam()->create();
+        $item = Item::factory()->for($user->currentTeam)->create([
+            'metadata' => ['url' => 'https://example.com'],
+        ]);
 
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('navigateDown', $bedroom->id)
-        ->call('navigateDown', $closet->id)
-        ->assertSeeHtml('<span>Game Tote</span>')
-        ->call('navigateDown', $bedroom->id)
-        ->assertSet('parentId', $bedroom->id)
-        ->assertSeeHtml('<span>Right Closet</span>')
-        ->assertDontSeeHtml('<span>Game Tote</span>');
-});
-
-test('create pre-fills parent_id with current parentId', function () {
-    $user = User::factory()->withTeam()->create();
-    $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
-
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('navigateDown', $parent->id)
-        ->call('create')
-        ->assertSet('form.parent_id', $parent->id);
-});
-
-test('create does not pre-fill parent_id at root level', function () {
-    $user = User::factory()->withTeam()->create();
-
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('create')
-        ->assertSet('form.parent_id', null);
-});
-
-test('create resets form before pre-filling parent_id', function () {
-    $user = User::factory()->withTeam()->create();
-    $parent = Item::factory()->for($user->currentTeam)->location()->create(['name' => 'Bedroom']);
-    $item = Item::factory()->for($user->currentTeam)->childOf($parent)->create(['name' => 'Guitar']);
-
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('navigateDown', $parent->id)
-        ->call('edit', $item->id)
-        ->assertSet('form.name', 'Guitar')
-        ->call('create')
-        ->assertSet('form.name', '')
-        ->assertSet('form.parent_id', $parent->id);
-});
-
-test('deleting a parent nullifies children parent_id', function () {
-    $user = User::factory()->withTeam()->create();
-    $parent = Item::factory()->for($user->currentTeam)->location()->create();
-    $child = Item::factory()->for($user->currentTeam)->childOf($parent)->create();
-
-    Livewire::actingAs($user)
-        ->test('pages::inventory.index')
-        ->call('delete', $parent->id);
-
-    expect($child->fresh()->parent_id)->toBeNull();
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('edit', $item->id)
+            ->assertSet('form.metadata', [
+                ['key' => 'url', 'value' => 'https://example.com'],
+            ]);
+    });
 });

--- a/resources/views/pages/inventory/⚡index.test.php
+++ b/resources/views/pages/inventory/⚡index.test.php
@@ -345,6 +345,21 @@ describe('can add item metadata', function () {
         expect($item->metadata)->toBeNull();
     });
 
+    test('metadata value is required when key is present', function () {
+        $user = User::factory()->withTeam()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('create')
+            ->set('form.name', 'Missing Value Item')
+            ->set('form.type', ItemType::Item->value)
+            ->set('form.metadata', [
+                ['key' => 'color', 'value' => ''],
+            ])
+            ->call('save')
+            ->assertHasErrors('form.metadata.0.value');
+    });
+
     test('duplicate metadata keys are rejected', function () {
         $user = User::factory()->withTeam()->create();
 

--- a/resources/views/pages/inventory/⚡index.test.php
+++ b/resources/views/pages/inventory/⚡index.test.php
@@ -345,6 +345,22 @@ describe('can add item metadata', function () {
         expect($item->metadata)->toBeNull();
     });
 
+    test('duplicate metadata keys are rejected', function () {
+        $user = User::factory()->withTeam()->create();
+
+        Livewire::actingAs($user)
+            ->test('pages::inventory.index')
+            ->call('create')
+            ->set('form.name', 'Dupe Keys Item')
+            ->set('form.type', ItemType::Item->value)
+            ->set('form.metadata', [
+                ['key' => 'color', 'value' => 'red'],
+                ['key' => 'color', 'value' => 'blue'],
+            ])
+            ->call('save')
+            ->assertHasErrors('form.metadata.1.key');
+    });
+
     test('editing an item loads existing metadata', function () {
         $user = User::factory()->withTeam()->create();
         $item = Item::factory()->for($user->currentTeam)->create([


### PR DESCRIPTION
This pull request adds support for storing and managing arbitrary metadata as key-value pairs on inventory items. It includes backend changes to the data model and form logic, frontend updates to display and edit metadata fields, and comprehensive tests for the new functionality.

**Metadata support for inventory items**

* Added a new nullable JSON `metadata` column to the `items` table via migration.
* Updated the `Item` model to include `metadata` in `$fillable` and cast it as an array. [[1]](diffhunk://#diff-b0b341893e1e3c0d6bb6841799a11e715abcc606e5134dce63a10cb886c6160bR25) [[2]](diffhunk://#diff-b0b341893e1e3c0d6bb6841799a11e715abcc606e5134dce63a10cb886c6160bR51)

**Form and validation changes**

* Enhanced the `ItemForm` Livewire form to support an array of metadata key-value pairs, including methods to add/remove metadata fields, load existing metadata, and process metadata on save (filtering out empty keys and storing as associative array or null).
* Updated validation rules to support the new metadata structure.

**Frontend UI updates**

* Modified the inventory item form UI to allow users to add, edit, and remove metadata fields dynamically.
* Connected UI actions to the new form methods for managing metadata.

**Testing enhancements**

* Added a suite of tests covering creation, editing, filtering, and loading of item metadata, ensuring correct backend storage and UI behavior.