### PR TITLE
Move show trashed to filter menu

### DIFF
--- a/resources/views/pages/inventory/⚡index/index.blade.php
+++ b/resources/views/pages/inventory/⚡index/index.blade.php
@@ -42,10 +42,11 @@
         <div class="flex items-center gap-1">
             <flux:input wire:model.live.debounce.300ms="search" :placeholder="__('Search inventory...')" icon="magnifying-glass" class="max-w-sm" />
             <flux:dropdown>
-                <flux:button :variant="($filters['withoutHome'] ?? false) ? 'primary' : 'ghost'" :color="($filters['withoutHome'] ?? false) ? 'sky' : ''" icon="funnel" icon:variant="outline"/>
+                <flux:button :variant="$this->areFiltersActive ? 'primary' : 'ghost'" :color="$this->areFiltersActive ? 'sky' : ''" icon="funnel" icon:variant="outline"/>
 
                 <flux:menu>
                     <flux:menu.checkbox wire:model.live="filters.withoutHome" :disabled="$parentId !== null">{{ __('Without home') }}</flux:menu.checkbox>
+                    <flux:menu.checkbox wire:model.live="filters.showTrashed">{{ __('Show deleted') }}</flux:menu.checkbox>
                 </flux:menu>
             </flux:dropdown>
             @if ($selected !== [])
@@ -57,7 +58,7 @@
 
                     <flux:menu.separator />
 
-                    @if ($showTrashed)
+                    @if ($filters['showTrashed'] ?? false)
                     <flux:menu.item wire:click="bulkRestore" icon="arrow-uturn-left">{{ __('Restore') }}</flux:menu.item>
                     @else
                     <flux:menu.item wire:click="bulkDelete" wire:confirm="{{ __('Are you sure you want to delete the selected items?') }}" variant="danger" icon="trash">{{ __('Delete') }}</flux:menu.item>
@@ -66,7 +67,6 @@
             </flux:dropdown>
             @endif
         </div>
-        <flux:switch wire:model.live="showTrashed" label="{{ __('Show deleted') }}" />
     </div>
 
     <flux:checkbox.group wire:model.live="selected">
@@ -96,7 +96,7 @@
                         {{ $item->children_count }}
                     </flux:table.cell>
                     <flux:table.cell>
-                        @if ($showTrashed)
+                        @if ($filters['showTrashed'] ?? false)
                             <div class="flex items-center gap-1">
                                 <flux:button wire:click="restore({{ $item->id }})" wire:confirm="{{ __('Are you sure you want to restore this item?') }}" variant="ghost" size="sm" icon="arrow-uturn-left">{{ __('Restore') }}</flux:button>
                                 <flux:button wire:click="forceDelete({{ $item->id }})" wire:confirm="{{ __('Are you sure you want to permanently delete this item? This cannot be undone.') }}" variant="danger" size="sm" icon="trash">{{ __('Delete Forever') }}</flux:button>

--- a/resources/views/pages/inventory/⚡index/index.php
+++ b/resources/views/pages/inventory/⚡index/index.php
@@ -42,17 +42,21 @@ new #[Title('Inventory')] class extends Component
 
     public ?int $bulkParentId = null;
 
-    #[Url]
-    public bool $showTrashed = false;
-
     /** @var array<string, bool> */
     #[Url]
     public array $filters = [
         'withoutHome' => false,
+        'showTrashed' => false,
     ];
 
     #[Url]
     public ?int $parentId = null;
+
+    #[Computed]
+    public function areFiltersActive(): bool
+    {
+        return collect($this->filters)->contains(true);
+    }
 
     #[Computed]
     public function breadcrumbs(): BaseCollection
@@ -75,7 +79,7 @@ new #[Title('Inventory')] class extends Component
     {
         return Auth::user()->currentTeam
             ->items()
-            ->when($this->showTrashed, fn ($query) => $query->onlyTrashed())
+            ->when($this->filters['showTrashed'] ?? false, fn ($query) => $query->onlyTrashed())
             ->withCount('children')
             ->when(
                 $this->filters['withoutHome'] ?? false,

--- a/resources/views/pages/inventory/⚡index/index.test.php
+++ b/resources/views/pages/inventory/⚡index/index.test.php
@@ -303,7 +303,7 @@ describe('can view and restore deleted items', function () {
             ->test('pages::inventory.index')
             ->assertSeeHtml('<span>Active Widget</span>')
             ->assertDontSeeHtml('<span>Deleted Widget</span>')
-            ->set('showTrashed', true)
+            ->set('filters.showTrashed', true)
             ->assertSeeHtml('<span>Deleted Widget</span>')
             ->assertDontSeeHtml('<span>Active Widget</span>');
     });
@@ -315,7 +315,7 @@ describe('can view and restore deleted items', function () {
 
         Livewire::actingAs($user)
             ->test('pages::inventory.index')
-            ->set('showTrashed', true)
+            ->set('filters.showTrashed', true)
             ->assertSee('Restored Widget')
             ->call('restore', $item->id);
 
@@ -331,7 +331,7 @@ describe('can view and restore deleted items', function () {
 
         Livewire::actingAs($user)
             ->test('pages::inventory.index')
-            ->set('showTrashed', true)
+            ->set('filters.showTrashed', true)
             ->call('restore', $item->id);
     })->throws(ModelNotFoundException::class);
 });
@@ -344,7 +344,7 @@ describe('can permanently delete items', function () {
 
         Livewire::actingAs($user)
             ->test('pages::inventory.index')
-            ->set('showTrashed', true)
+            ->set('filters.showTrashed', true)
             ->call('forceDelete', $item->id);
 
         expect($item->fresh())->toBeNull();
@@ -357,7 +357,7 @@ describe('can permanently delete items', function () {
 
         Livewire::actingAs($user)
             ->test('pages::inventory.index')
-            ->set('showTrashed', true)
+            ->set('filters.showTrashed', true)
             ->call('forceDelete', $item->id);
     })->throws(ModelNotFoundException::class);
 });


### PR DESCRIPTION
This PR moves the "show trashed" switch to the filter menu.

**Before:**
<img width="954" height="415" alt="Screenshot 2026-03-16 at 6 06 35 PM" src="https://github.com/user-attachments/assets/2b8cdc1f-0e7b-4430-a8a5-94382d62c1db" />

**After:**
<img width="954" height="453" alt="Screenshot 2026-03-16 at 6 07 09 PM" src="https://github.com/user-attachments/assets/4d4e01d7-3ddc-43d4-8feb-6f2eeef9c68f" />
