### PR TITLE
Store calendar errors for user info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sunny
 
 **PHP:** 8.4
-**Laravel:** 12
+**Laravel:** 13
 **Node:** 22
 **Asset Compiler:** Vite
 **Database:** Postgres 18
@@ -10,15 +10,25 @@
 **Hosting:** Cloud
 **Monitoring:** Nightwatch
 
-**Notible Composer Packages:**
+**Notable Composer Packages:**
+- [bentonow/bento-laravel-sdk](https://github.com/bentonow/bento-laravel-sdk)
+- [dedoc/scramble](https://scramble.dedoc.co/)
 - [driftingly/rector-laravel](https://github.com/driftingly/rector-laravel)
-- [livewire/flux-pro](https://fluxui.dev/)
 - [laravel/boost](https://github.com/laravel/boost)
-- [laravel/pennant](https://github.com/laravel/pennant)
+- [laravel/chisel](https://github.com/laravel/chisel)
+- [laravel/fortify](https://github.com/laravel/fortify)
 - [laravel/pao](https://github.com/laravel/pao)
+- [laravel/pennant](https://github.com/laravel/pennant)
+- [livewire/flux-pro](https://fluxui.dev/)
 - [nunomaduro/essentials](https://github.com/nunomaduro/essentials)
+- [petebishwhip/laradocs](https://github.com/PeteBishwhip/laradocs)
+- [sabre/vobject](https://github.com/sabre-io/vobject)
+- [saloonphp/saloon](https://docs.saloon.dev/)
+- [spatie/simple-excel](https://github.com/spatie/simple-excel)
+- [tightenco/duster](https://github.com/tighten/duster)
 
-**Notible NPM Packages:**
+**Notable NPM Packages:**
+- [@laravel/passkeys](https://www.npmjs.com/package/@laravel/passkeys)
 - [playwright](https://github.com/microsoft/playwright)
 - [tailwindcss](https://tailwindcss.com/)
 - [tailwindcss/typography](https://github.com/tailwindlabs/tailwindcss-typography)
@@ -77,33 +87,37 @@ erDiagram
 
 	teams {
 		integer id PK ""
-		integer user_id FK ""
 		varchar name  ""
+		varchar slug UK ""
+		boolean is_personal  ""
+		varchar timezone  ""
+		integer week_start  ""
+		json address  ""
+		varchar appearance  ""
+		varchar layout  ""
+		datetime deleted_at  ""
 		datetime created_at  ""
 		datetime updated_at  ""
 	}
 
-	team_user {
+	team_members {
 		integer id PK ""
 		integer team_id FK ""
 		integer user_id FK ""
+		varchar role  ""
 		datetime created_at  ""
 		datetime updated_at  ""
-	}
-
-	sessions {
-		varchar id PK ""
-		integer user_id FK ""
-		varchar ip_address  ""
-		text user_agent  ""
-		text payload  ""
-		integer last_activity  ""
 	}
 
 	team_invitations {
 		integer id PK ""
 		integer team_id FK ""
+		integer invited_by FK ""
 		varchar email  ""
+		varchar role  ""
+		varchar code UK ""
+		datetime expires_at  ""
+		datetime accepted_at  ""
 		datetime created_at  ""
 		datetime updated_at  ""
 	}
@@ -127,6 +141,7 @@ erDiagram
 		text nutrition  ""
 		json tags  ""
 		varchar photo_path  ""
+		datetime deleted_at  ""
 		datetime created_at  ""
 		datetime updated_at  ""
 	}
@@ -137,11 +152,63 @@ erDiagram
 		integer parent_id FK ""
 		varchar type  ""
 		varchar name  ""
+		json metadata  ""
+		varchar photo_path  ""
+		datetime deleted_at  ""
 		datetime created_at  ""
 		datetime updated_at  ""
 	}
 
-password_reset_tokens {
+	calendar_feeds {
+		integer id PK ""
+		integer team_id FK ""
+		varchar name  ""
+		text url  ""
+		varchar color  ""
+		datetime last_fetched_at  ""
+		datetime last_failed_at  ""
+		varchar last_error  ""
+		datetime created_at  ""
+		datetime updated_at  ""
+	}
+
+	kiosk_devices {
+		integer id PK ""
+		varchar uuid UK ""
+		varchar pairing_code UK ""
+		varchar name  ""
+		varchar user_agent  ""
+		varchar last_ip  ""
+		integer user_id FK ""
+		integer team_id FK ""
+		datetime paired_at  ""
+		datetime expires_at  ""
+		datetime last_seen_at  ""
+		datetime created_at  ""
+		datetime updated_at  ""
+	}
+
+	passkeys {
+		integer id PK ""
+		integer user_id FK ""
+		varchar name  ""
+		varchar credential_id UK ""
+		json credential  ""
+		datetime last_used_at  ""
+		datetime created_at  ""
+		datetime updated_at  ""
+	}
+
+	sessions {
+		varchar id PK ""
+		integer user_id FK ""
+		varchar ip_address  ""
+		text user_agent  ""
+		text payload  ""
+		integer last_activity  ""
+	}
+
+	password_reset_tokens {
 		varchar email PK ""
 		varchar token  ""
 		datetime created_at  ""
@@ -160,14 +227,18 @@ password_reset_tokens {
 		datetime updated_at  ""
 	}
 
-	users||--o{teams:"owns"
-	users||--o{team_user:"belongs to"
+	users||--o{team_members:"belongs to"
 	users||--o|teams:"current team"
+	users||--o{team_invitations:"invited by"
+	users||--o{passkeys:"has"
+	users||--o{kiosk_devices:"paired"
 	users||--o{sessions:"has"
-	teams||--o{team_user:"has members"
+	teams||--o{team_members:"has members"
 	teams||--o{team_invitations:"has invitations"
 	teams||--o{recipes:"has"
 	teams||--o{items:"has"
+	teams||--o{calendar_feeds:"has"
+	teams||--o{kiosk_devices:"has"
 	recipes||--o{recipes:"remix of"
 	items||--o{items:"nested in"
 

--- a/app/Actions/Calendars/FetchCalendarEvents.php
+++ b/app/Actions/Calendars/FetchCalendarEvents.php
@@ -8,12 +8,15 @@ use App\Models\CalendarFeed;
 use Carbon\CarbonImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Sabre\VObject\Component\VEvent;
 use Sabre\VObject\DateTimeParser;
 use Sabre\VObject\Reader;
+use Throwable;
 
 class FetchCalendarEvents
 {
@@ -32,16 +35,19 @@ class FetchCalendarEvents
      */
     public function handle(CalendarFeed $feed, int $days = 30, ?CarbonImmutable $from = null): Collection
     {
-        $body = Cache::remember(
-            key: "calendar-feed:{$feed->id}:" . md5($feed->url),
-            ttl: now()->addMinutes(15),
-            callback: fn () => Http::withHeaders([
-                'Accept' => 'text/calendar,text/plain,*/*',
-                'User-Agent' => 'SunnyCalendar/1.0',
-            ])->timeout(10)->get($feed->url)->throw()->body(),
-        );
+        $body = $this->body($feed);
 
-        return $this->parse($body, $feed, $from ?? CarbonImmutable::now($this->timezoneName($feed)), $days);
+        if ($body === null) {
+            return collect();
+        }
+
+        try {
+            return $this->parse($body, $feed, $from ?? CarbonImmutable::now($this->timezoneName($feed)), $days);
+        } catch (Throwable $exception) {
+            $feed->fetched($exception);
+
+            return collect();
+        }
     }
 
     /**
@@ -163,5 +169,44 @@ class FetchCalendarEvents
     private function timezoneName(CalendarFeed $feed): string
     {
         return $feed->team?->timezone ?: 'America/Chicago';
+    }
+
+    /**
+     * Fetch the feed body, caching successful responses for 15 minutes and
+     * failures for 5 minutes so a broken feed doesn't slow every render.
+     */
+    private function body(CalendarFeed $feed): ?string
+    {
+        $cacheKey = "calendar-feed:{$feed->id}:" . md5($feed->url);
+
+        /** @var string|false|null $cached */
+        $cached = Cache::get($cacheKey);
+
+        if ($cached === null) {
+            $cached = $this->fetch($feed, $cacheKey);
+        }
+
+        return $cached === false ? null : $cached;
+    }
+
+    private function fetch(CalendarFeed $feed, string $cacheKey): string|false
+    {
+        try {
+            $body = Http::withHeaders([
+                'Accept' => 'text/calendar,text/plain,*/*',
+                'User-Agent' => 'SunnyCalendar/1.0',
+            ])->timeout(10)->get($feed->url)->throw()->body();
+        } catch (Throwable $exception) {
+            $feed->fetched($exception);
+            Cache::put($cacheKey, false, now()->addMinutes(5));
+
+            return false;
+        }
+
+        $feed->fetched();
+
+        Cache::put($cacheKey, $body, now()->addMinutes(15));
+
+        return $body;
     }
 }

--- a/app/Actions/Calendars/FetchCalendarEvents.php
+++ b/app/Actions/Calendars/FetchCalendarEvents.php
@@ -8,8 +8,6 @@ use App\Models\CalendarFeed;
 use Carbon\CarbonImmutable;
 use DateTimeInterface;
 use DateTimeZone;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;

--- a/app/Actions/Kiosk/UpdateFeed.php
+++ b/app/Actions/Kiosk/UpdateFeed.php
@@ -11,6 +11,10 @@ class UpdateFeed
     /** @param  array<string, mixed>  $data */
     public function handle(CalendarFeed $feed, array $data): CalendarFeed
     {
+        if (isset($data['url']) && $data['url'] !== $feed->url) {
+            $feed->fetched();
+        }
+
         $feed->update($data);
 
         return $feed;

--- a/app/Models/CalendarFeed.php
+++ b/app/Models/CalendarFeed.php
@@ -10,6 +10,9 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Throwable;
 
 #[Fillable(['team_id', 'name', 'url', 'color'])]
 class CalendarFeed extends Model
@@ -23,11 +26,40 @@ class CalendarFeed extends Model
         return $this->belongsTo(Team::class);
     }
 
+    public function fetched(?Throwable $exception = null)
+    {
+        if ($exception) {
+            $this->update([
+                'last_failed_at' => now(),
+                'last_error' => match (true) {
+                    $exception instanceof RequestException => __('The calendar server responded with HTTP :status.', ['status' => $exception->response->status()]),
+                    $exception instanceof ConnectionException => __('Could not connect to the calendar server.'),
+                    default => __('The calendar feed could not be read.'),
+                },
+            ]);
+
+            return;
+        }
+
+        $this->update([
+            'last_fetched_at' => now(),
+            'last_failed_at' => null,
+            'last_error' => null,
+        ]);
+    }
+
+    public function isFailing(): bool
+    {
+        return $this->last_failed_at !== null;
+    }
+
     /** @return array<string, string> */
     protected function casts(): array
     {
         return [
             'color' => CalendarColor::class,
+            'last_fetched_at' => 'datetime',
+            'last_failed_at' => 'datetime',
         ];
     }
 }

--- a/database/factories/CalendarFeedFactory.php
+++ b/database/factories/CalendarFeedFactory.php
@@ -24,4 +24,12 @@ class CalendarFeedFactory extends Factory
             'color' => fake()->randomElement(CalendarColor::class),
         ];
     }
+
+    public function failing(): static
+    {
+        return $this->state([
+            'last_failed_at' => now(),
+            'last_error' => 'The calendar server responded with HTTP 401.',
+        ]);
+    }
 }

--- a/database/migrations/2026_07_07_203204_add_health_columns_to_calendar_feeds_table.php
+++ b/database/migrations/2026_07_07_203204_add_health_columns_to_calendar_feeds_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('calendar_feeds', function (Blueprint $table) {
+            $table->timestamp('last_fetched_at')->nullable();
+            $table->timestamp('last_failed_at')->nullable();
+            $table->string('last_error')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('calendar_feeds', function (Blueprint $table) {
+            $table->dropColumn(['last_fetched_at', 'last_failed_at', 'last_error']);
+        });
+    }
+};

--- a/resources/views/pages/kiosk/configure/⚡calendar/calendar.blade.php
+++ b/resources/views/pages/kiosk/configure/⚡calendar/calendar.blade.php
@@ -14,6 +14,10 @@
                         <flux:heading class="flex items-center gap-2">
                             <span class="size-2.5 shrink-0 rounded-full" style="background: {{ $feed->color }}"></span>
                             <span class="truncate font-medium">{{ $feed->name }}</span>
+
+                            @if ($feed->isFailing())
+                                <flux:badge color="amber" size="sm" icon="exclamation-triangle">{{ __('Failing') }}</flux:badge>
+                            @endif
                         </flux:heading>
 
                         <flux:text variant="subtle" class="truncate max-w-64" title="{{ $feed->url }}">{{ $feed->url }}</flux:text>
@@ -29,6 +33,15 @@
                         </flux:tooltip>
                     </div>
                 </div>
+
+                @if ($feed->isFailing())
+                    <flux:callout variant="warning" icon="exclamation-triangle" class="mt-2">
+                        <flux:callout.heading>{{ $feed->last_error }}</flux:callout.heading>
+                        <flux:callout.text>
+                            {{ __('Last failed :time. Check that the URL is correct and the calendar is still shared. For Google Calendar, copy a fresh "Secret address in iCal format" from the calendar settings and update the URL here.', ['time' => $feed->last_failed_at->diffForHumans()]) }}
+                        </flux:callout.text>
+                    </flux:callout>
+                @endif
             </flux:card>
         @empty
             <div class="rounded-lg border border-dashed border-zinc-300 p-4 text-sm text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">

--- a/resources/views/pages/kiosk/configure/⚡calendar/calendar.test.php
+++ b/resources/views/pages/kiosk/configure/⚡calendar/calendar.test.php
@@ -105,6 +105,47 @@ test('can remove a team calendar feed', function () {
     ]);
 });
 
+test('shows failure details for a failing feed', function () {
+    $team = Team::factory()
+        ->has(CalendarFeed::factory()->failing()->state([
+            'name' => 'Work Calendar',
+            'url' => 'https://example.com/work.ics',
+            'color' => CalendarColor::Red,
+        ]))
+        ->create();
+    $user = User::factory()->memberOf($team)->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::kiosk.configure.calendar')
+        ->assertSee('Failing')
+        ->assertSee('The calendar server responded with HTTP 401.')
+        ->assertSee('Secret address in iCal format');
+});
+
+test('updating a feed url clears its failure state', function () {
+    $team = Team::factory()
+        ->has(CalendarFeed::factory()->failing()->state([
+            'name' => 'Work Calendar',
+            'url' => 'https://example.com/work.ics',
+            'color' => CalendarColor::Red,
+        ]))
+        ->create();
+    $user = User::factory()->memberOf($team)->create();
+    $feed = $team->calendarFeeds()->firstOrFail();
+
+    Livewire::actingAs($user)
+        ->test('pages::kiosk.configure.calendar')
+        ->call('edit', $feed->id)
+        ->set('form.url', 'https://example.com/work-fixed.ics')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $feed->refresh();
+
+    expect($feed->isFailing())->toBeFalse()
+        ->and($feed->last_error)->toBeNull();
+});
+
 test('validates calendar feed input', function () {
     $user = User::factory()->create();
 

--- a/resources/views/pages/kiosk/⚡calendar/calendar.blade.php
+++ b/resources/views/pages/kiosk/⚡calendar/calendar.blade.php
@@ -3,6 +3,20 @@
         <x-ui.clock :timezone="auth()->user()->currentTeam->timezone"/>
 
         <div class="flex items-center gap-2">
+            @if ($this->failedFeeds->isNotEmpty())
+            <flux:dropdown>
+                <flux:button icon="exclamation-triangle" variant="primary" color="yellow"/>
+
+                <flux:popover>
+                    <flux:heading>
+                        {{ __("Couldn't load :feeds.", ['feeds' => $this->failedFeeds->pluck('name')->join(', ', __(' and '))]) }}
+                    </flux:heading>
+                    <flux:text>
+                        {{ __('Open Sunny on your phone or computer and go to Configure → Calendar to fix it.') }}
+                    </flux:text>
+                </flux:popover>
+            </flux:dropdown>
+            @endif
             <flux:dropdown>
                 <flux:button icon="funnel" icon:variant="outline" />
                 <flux:menu keep-open>

--- a/resources/views/pages/kiosk/⚡calendar/calendar.php
+++ b/resources/views/pages/kiosk/⚡calendar/calendar.php
@@ -36,6 +36,28 @@ new #[Layout('layouts::kiosk')] class extends Component
             ->get();
     }
 
+    /**
+     * Feeds that failed their most recent fetch. Reads the events for the
+     * current format first so fetches run before health is checked, keeping
+     * the banner in sync with this render instead of the previous one.
+     *
+     * @return EloquentCollection<int, CalendarFeed>
+     */
+    #[Computed]
+    public function failedFeeds(): EloquentCollection
+    {
+        match ($this->format) {
+            'day' => $this->dayEvents,
+            'month' => $this->monthEvents,
+            default => $this->weekEvents,
+        };
+
+        return $this->feeds
+            ->whereIn('id', $this->selectedFeeds)
+            ->filter(fn (CalendarFeed $feed): bool => $feed->isFailing())
+            ->values();
+    }
+
     /** @return array<int, array<string, mixed>> */
     #[Computed]
     public function dayEvents(): array
@@ -236,7 +258,7 @@ new #[Layout('layouts::kiosk')] class extends Component
 
     private function clearCalendarState(): void
     {
-        unset($this->dayEvents, $this->day, $this->dayAllDayEvents, $this->dayTimedEvents, $this->weekEvents, $this->weekDays, $this->monthEvents, $this->monthDays);
+        unset($this->dayEvents, $this->day, $this->dayAllDayEvents, $this->dayTimedEvents, $this->weekEvents, $this->weekDays, $this->monthEvents, $this->monthDays, $this->failedFeeds);
     }
 
     private function timezoneName(): string

--- a/resources/views/pages/kiosk/⚡calendar/calendar.test.php
+++ b/resources/views/pages/kiosk/⚡calendar/calendar.test.php
@@ -237,10 +237,112 @@ ICS),
         ->assertDontSee('Third Event');
 });
 
+test('shows a warning banner when a feed fails to load', function () {
+    Http::fake([
+        'https://example.com/good.ics' => Http::response(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sunny//Tests//EN
+BEGIN:VEVENT
+UID:morning-standup
+DTSTAMP:20260501T120000Z
+DTSTART;TZID=America/Chicago:20260508T090000
+DTEND;TZID=America/Chicago:20260508T103000
+SUMMARY:Morning Standup
+END:VEVENT
+END:VCALENDAR
+ICS),
+        'https://example.com/broken.ics' => Http::response('<!DOCTYPE html>Unauthorized', 401),
+    ]);
+
+    $this->travelTo(Date::parse('2026-05-08 12:00:00', 'America/Chicago'));
+
+    $team = Team::factory()
+        ->has(
+            CalendarFeed::factory()
+                ->count(2)
+                ->sequence([
+                    'url' => 'https://example.com/good.ics',
+                    'name' => 'Family Calendar',
+                    'color' => CalendarColor::Blue,
+                ], [
+                    'url' => 'https://example.com/broken.ics',
+                    'name' => 'Work Calendar',
+                    'color' => CalendarColor::Red,
+                ])
+        )
+        ->create();
+    $user = User::factory()->memberOf($team)->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::kiosk.calendar')
+        ->assertSee("Couldn't load Work Calendar.")
+        ->assertSee('Open Sunny on your phone or computer')
+        ->assertSee('Morning Standup');
+
+    expect($team->calendarFeeds()->firstWhere('name', 'Work Calendar')->isFailing())->toBeTrue()
+        ->and($team->calendarFeeds()->firstWhere('name', 'Family Calendar')->isFailing())->toBeFalse();
+});
+
+test('does not show a warning banner when all feeds load', function () {
+    Http::fake([
+        'https://example.com/good.ics' => Http::response(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sunny//Tests//EN
+END:VCALENDAR
+ICS),
+    ]);
+
+    $team = Team::factory()
+        ->has(CalendarFeed::factory()->state([
+            'url' => 'https://example.com/good.ics',
+            'name' => 'Family Calendar',
+            'color' => CalendarColor::Blue,
+        ]))
+        ->create();
+    $user = User::factory()->memberOf($team)->create();
+
+    Livewire::actingAs($user)
+        ->test('pages::kiosk.calendar')
+        ->assertDontSee("Couldn't load");
+});
+
 test('can hide feed from calendar', function () {
-    Http::allowStrayRequests([
-        'https://calendar.google.com/calendar/ical/*',
-        'https://worldpublicholiday.com/calendar-feeds/*',
+    Http::fake([
+        'https://example.com/us.ics' => Http::response(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sunny//Tests//EN
+BEGIN:VEVENT
+UID:st-patricks-day
+DTSTAMP:20260301T120000Z
+DTSTART;VALUE=DATE:20260317
+DTEND;VALUE=DATE:20260318
+SUMMARY:St. Patrick's Day
+END:VEVENT
+END:VCALENDAR
+ICS),
+        'https://example.com/br.ics' => Http::response(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sunny//Tests//EN
+BEGIN:VEVENT
+UID:autonomia-do-estado
+DTSTAMP:20260301T120000Z
+DTSTART;VALUE=DATE:20260318
+DTEND;VALUE=DATE:20260319
+SUMMARY:Autonomia do Estado
+END:VEVENT
+BEGIN:VEVENT
+UID:dia-de-sao-jose
+DTSTAMP:20260301T120000Z
+DTSTART;VALUE=DATE:20260319
+DTEND;VALUE=DATE:20260320
+SUMMARY:Dia de São José
+END:VEVENT
+END:VCALENDAR
+ICS),
     ]);
 
     $this->travelTo(Date::parse('2026-03-20'));
@@ -250,11 +352,11 @@ test('can hide feed from calendar', function () {
             CalendarFeed::factory()
                 ->count(2)
                 ->sequence([
-                    'url' => 'https://calendar.google.com/calendar/ical/en.usa%23holiday%40group.v.calendar.google.com/public/basic.ics',
+                    'url' => 'https://example.com/us.ics',
                     'name' => 'US Holidays',
                     'color' => CalendarColor::Green,
                 ], [
-                    'url' => 'https://worldpublicholiday.com/calendar-feeds/feed.ics?country=BR&year=2026',
+                    'url' => 'https://example.com/br.ics',
                     'name' => 'Brazilian Holidays',
                     'color' => CalendarColor::Blue,
                 ])

--- a/tests/Unit/Actions/FetchCalendarEventsTest.php
+++ b/tests/Unit/Actions/FetchCalendarEventsTest.php
@@ -6,6 +6,7 @@ use App\Models\CalendarFeed;
 use App\Models\Team;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Http;
 
 test('it checks attendee response status against team member emails', function () {
     $team = Team::factory()->create();
@@ -46,4 +47,61 @@ ICS,
 
     expect($events)->toHaveCount(1)
         ->and($events->first()['response_status'])->toBe('ACCEPTED');
+});
+
+test('it records a failure and returns no events when the feed cannot be fetched', function () {
+    Http::fake([
+        'https://example.com/broken.ics' => Http::response('<!DOCTYPE html>Unauthorized', 401),
+    ]);
+
+    $feed = CalendarFeed::factory()->create(['url' => 'https://example.com/broken.ics']);
+
+    $events = resolve(FetchCalendarEvents::class)->handle($feed);
+
+    $feed->refresh();
+
+    expect($events)->toBeEmpty()
+        ->and($feed->isFailing())->toBeTrue()
+        ->and($feed->last_error)->toBe('The calendar server responded with HTTP 401.');
+});
+
+test('it caches failures so a broken feed is not fetched on every render', function () {
+    Http::fake([
+        'https://example.com/broken.ics' => Http::response('', 401),
+    ]);
+
+    $feed = CalendarFeed::factory()->create(['url' => 'https://example.com/broken.ics']);
+
+    resolve(FetchCalendarEvents::class)->handle($feed);
+    resolve(FetchCalendarEvents::class)->handle($feed);
+
+    Http::assertSentCount(1);
+});
+
+test('it clears the failure state after a successful fetch', function () {
+    Http::fake([
+        'https://example.com/fixed.ics' => Http::response(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sunny//Calendar Test//EN
+BEGIN:VEVENT
+UID:crew-meeting@example.com
+DTSTAMP:20260501T120000Z
+DTSTART:20260505T150000Z
+DTEND:20260505T160000Z
+SUMMARY:Crew Meeting
+END:VEVENT
+END:VCALENDAR
+ICS),
+    ]);
+
+    $feed = CalendarFeed::factory()->failing()->create(['url' => 'https://example.com/fixed.ics']);
+
+    resolve(FetchCalendarEvents::class)->handle($feed);
+
+    $feed->refresh();
+
+    expect($feed->isFailing())->toBeFalse()
+        ->and($feed->last_error)->toBeNull()
+        ->and($feed->last_fetched_at)->not->toBeNull();
 });


### PR DESCRIPTION
A user using the kiosk experienced a 500 error, totally blanking out the whole page. This was due to a calendar returning a 401. Instead of blocking the whole screen, this PR catches the error and displays a warning with instructions to visit the website to update the feed url.